### PR TITLE
change ConsentSignature.birthdate from DateTime (full timestamp) to LocalDate (calendar date)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/users/ConsentSignature.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/users/ConsentSignature.java
@@ -1,16 +1,17 @@
 package org.sagebionetworks.bridge.sdk.models.users;
 
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
+import org.joda.time.LocalDate;
+import org.joda.time.format.ISODateTimeFormat;
 
 public class ConsentSignature {
 
     private final String name;
-    private final DateTime birthdate;
+    private final LocalDate birthdate;
     private final String imageData;
     private final String imageMimeType;
 
@@ -33,7 +34,8 @@ public class ConsentSignature {
      *         signature image MIME type (ex: image/png), optional
      */
     @JsonCreator
-    public ConsentSignature(@JsonProperty("name") String name, @JsonProperty("birthdate") DateTime birthdate,
+    public ConsentSignature(@JsonProperty("name") String name, @JsonProperty("birthdate")
+            @JsonDeserialize(using=LocalDateDeserializer.class) LocalDate birthdate,
             @JsonProperty("imageData") String imageData, @JsonProperty("imageMimeType") String imageMimeType) {
         this.name = name;
         this.birthdate = birthdate;
@@ -47,10 +49,8 @@ public class ConsentSignature {
     }
 
     /** User's birth date. */
-    // TODO: We're using DateTime, which represents an instant in time, to represent a calendar date. Should we be
-    // using LocalDate instead?
     @JsonSerialize(using=DateOnlySerializer.class)
-    public DateTime getBirthdate() {
+    public LocalDate getBirthdate() {
         return birthdate;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/users/ConsentSignature.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/users/ConsentSignature.java
@@ -33,6 +33,8 @@ public class ConsentSignature {
      * @param imageMimeType
      *         signature image MIME type (ex: image/png), optional
      */
+    // We use the standard LocalDateDeserializer from jackson-datatype-joda. However, we still need to use a
+    // @JsonDeserialize annotation anyway or Jackson won't know what to do with it.
     @JsonCreator
     public ConsentSignature(@JsonProperty("name") String name, @JsonProperty("birthdate")
             @JsonDeserialize(using=LocalDateDeserializer.class) LocalDate birthdate,
@@ -49,6 +51,7 @@ public class ConsentSignature {
     }
 
     /** User's birth date. */
+    // We use a custom serializer, because the standard LocalDateSerializer serializes into a very unusual format.
     @JsonSerialize(using=DateOnlySerializer.class)
     public LocalDate getBirthdate() {
         return birthdate;

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/users/DateOnlySerializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/users/DateOnlySerializer.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.sdk.models.users;
 
 import java.io.IOException;
 
-import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -10,10 +10,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
-class DateOnlySerializer extends JsonSerializer<DateTime> {
+class DateOnlySerializer extends JsonSerializer<LocalDate> {
 
     @Override
-    public void serialize(DateTime date, JsonGenerator generator, SerializerProvider provider) throws IOException,
+    public void serialize(LocalDate date, JsonGenerator generator, SerializerProvider provider) throws IOException,
             JsonProcessingException {
         generator.writeString(date.toString(ISODateTimeFormat.date()));        
     }


### PR DESCRIPTION
ConsentSignature.birthdate is represented as a DateTime, which represents an instant in time. It makes more sense to represent this as a calendar date, especially since we transmit it to/from the server in YYYY-MM-DD format anyway. As such, I've changed it from using DateTime to using LocalDate, which represents a calendar date better.

I also added a unit test to test serializing to/from JSON, and added the Jackson Joda module LocalDateDeserializer to ConsentSignature to ensure proper deserialization.

Note: LocalDateDeserializer does exactly what we want it to do (although it accepts more formats than the server returns), but LocalDateSerializer does not.
