### PR TITLE
fix ConsentTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/TestUserHelper.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/TestUserHelper.java
@@ -75,7 +75,13 @@ public class TestUserHelper {
         
         List<String> rolesList = (roles == null) ? Collections.<String>emptyList() : Arrays.asList(roles);
         String name = makeUserName(cls);
-        SignUpCredentials signUp = new SignUpCredentials(name, name + "@sagebridge.org", "P4ssword");
+
+        // For email address, we don't want consent emails to bounce or SES will get mad at us. All test user email
+        // addresses should be in the form bridge-testing+[semi-unique token]@sagebase.org. This directs all test
+        // email to bridge-testing@sagebase.org.
+        String emailAddress = String.format("bridge-testing+%s@sagebase.org", name);
+
+        SignUpCredentials signUp = new SignUpCredentials(name, emailAddress, "P4ssword");
         adminClient.createUser(signUp, rolesList, consent);
 
         Session userSession = null;

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ConsentTest.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
@@ -42,13 +41,11 @@ public class ConsentTest {
     }
 
     @Test
-    @Ignore
     public void giveAndGetConsent() {
         giveAndGetConsentHelper("Eggplant McTester", new LocalDate(1970, 1, 1), null, null);
     }
 
     @Test
-    @Ignore
     public void giveAndGetConsentWithSignatureImage() {
         giveAndGetConsentHelper("Eggplant McTester", new LocalDate(1970, 1, 1), FAKE_IMAGE_DATA, "image/fake");
     }
@@ -98,7 +95,6 @@ public class ConsentTest {
     }
 
     @Test
-    @Ignore
     public void signedInUserMustGiveConsent() {
         TestUser user = TestUserHelper.createAndSignInUser(ConsentTest.class, false);
         try {


### PR DESCRIPTION
Includes the following changes:
- Fix TestUserHelper to create accounts with bridge-testing+[semi-unique token]@sagebase.org. This is so test emails don't impact our SES bounce rate.
- Make BaseApiCaller.toQueryString() URL encode query param values. Otherwise, they get garbled by the server. (Specifically, the +'s in test email addresses.)
- Re-enable ConsentTest.
