### PR TITLE
Java SDK prep work for Bridge Worker App

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Only a pre-release version exists at this time. Here's an example of referencing
 	    ...
 		<dependencies>
 			<dependency>
-			    <groupId>org.sagebionetworks</groupId>
+			    <groupId>org.sagebionetworks.bridge</groupId>
 			    <artifactId>java-sdk</artifactId>
 			    <version>develop-SNAPSHOT</version>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <version>1.4.0</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>1.3.9</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>18.0</version>

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import javax.annotation.Nonnull;
+
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
@@ -21,50 +23,49 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
     
-    private final TypeReference<ResourceListImpl<StudyConsent>> scType = new TypeReference<ResourceListImpl<StudyConsent>>() {};
-    private final TypeReference<ResourceListImpl<Survey>> sType = new TypeReference<ResourceListImpl<Survey>>() {};
-    private final TypeReference<ResourceListImpl<SchedulePlan>> spType = new TypeReference<ResourceListImpl<SchedulePlan>>() {};
+    private static final TypeReference<ResourceListImpl<StudyConsent>> scType =
+            new TypeReference<ResourceListImpl<StudyConsent>>() {};
+    private static final TypeReference<ResourceListImpl<Survey>> sType =
+            new TypeReference<ResourceListImpl<Survey>>() {};
+    private static final TypeReference<ResourceListImpl<SchedulePlan>> spType =
+            new TypeReference<ResourceListImpl<SchedulePlan>>() {};
 
-    private BridgeResearcherClient(BridgeSession session) {
-        super(session);
-    }
-
-    static BridgeResearcherClient valueOf(BridgeSession session) {
-        return new BridgeResearcherClient(session);
+    BridgeResearcherClient(@Nonnull BridgeSession session, @Nonnull ClientProvider clientProvider) {
+        super(session, clientProvider);
     }
 
     @Override
     public ResourceList<StudyConsent> getAllStudyConsents() {
         session.checkSignedIn();
 
-        return get(config.getStudyConsentsApi(), scType);
+        return get(clientProvider.getConfig().getStudyConsentsApi(), scType);
     }
     @Override
     public StudyConsent getMostRecentlyActivatedStudyConsent() {
         session.checkSignedIn();
 
-        return get(config.getActiveStudyConsentApi(), StudyConsent.class);
+        return get(clientProvider.getConfig().getActiveStudyConsentApi(), StudyConsent.class);
     }
     @Override
     public StudyConsent getStudyConsent(DateTime createdOn) {
         session.checkSignedIn();
         checkNotNull(createdOn, Bridge.CANNOT_BE_NULL, "createdOn");
 
-        return get(config.getStudyConsentApi(createdOn), StudyConsent.class);
+        return get(clientProvider.getConfig().getStudyConsentApi(createdOn), StudyConsent.class);
     }
     @Override
     public void createStudyConsent(StudyConsent consent) {
         session.checkSignedIn();
         checkNotNull(consent, Bridge.CANNOT_BE_NULL, "consent");
 
-        post(config.getStudyConsentsApi(), consent, StudyConsent.class);
+        post(clientProvider.getConfig().getStudyConsentsApi(), consent, StudyConsent.class);
     }
     @Override
     public void activateStudyConsent(DateTime createdOn) {
         session.checkSignedIn();
         checkNotNull(createdOn, Bridge.CANNOT_BE_NULL, "createdOn");
 
-        post(config.getVersionStudyConsentApi(createdOn));
+        post(clientProvider.getConfig().getVersionStudyConsentApi(createdOn));
     }
 
     @Override
@@ -72,47 +73,47 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
         session.checkSignedIn();
         checkArgument(isNotBlank(guid), Bridge.CANNOT_BE_BLANK, "guid");
         checkNotNull(createdOn, Bridge.CANNOT_BE_NULL, "createdOn");
-        return get(config.getSurveyApi(guid, createdOn), Survey.class);
+        return get(clientProvider.getConfig().getSurveyApi(guid, createdOn), Survey.class);
     }
     @Override
     public Survey getSurvey(GuidCreatedOnVersionHolder keys) {
         session.checkSignedIn();
         checkNotNull(keys, Bridge.CANNOT_BE_NULL, "guid/createdOn keys");
-        return get(config.getSurveyApi(keys.getGuid(), keys.getCreatedOn()), Survey.class);
+        return get(clientProvider.getConfig().getSurveyApi(keys.getGuid(), keys.getCreatedOn()), Survey.class);
     }
     @Override
     public ResourceList<Survey> getSurveyAllVersions(String guid) {
         session.checkSignedIn();
         checkArgument(isNotBlank(guid), Bridge.CANNOT_BE_BLANK, "guid");
-        return get(config.getSurveyVersionsApi(guid), sType);
+        return get(clientProvider.getConfig().getSurveyVersionsApi(guid), sType);
     }
     @Override
     public Survey getSurveyMostRecentlyPublishedVersion(String guid) {
         session.checkSignedIn();
         checkArgument(isNotBlank(guid), Bridge.CANNOT_BE_BLANK, "guid");
-        return get(config.getSurveyMostRecentlyPublishedVersionApi(guid), Survey.class);
+        return get(clientProvider.getConfig().getSurveyMostRecentlyPublishedVersionApi(guid), Survey.class);
     }
     @Override
     public Survey getSurveyMostRecentVersion(String guid) {
         session.checkSignedIn();
         checkArgument(isNotBlank(guid), Bridge.CANNOT_BE_BLANK, "guid");
-        return get(config.getSurveyMostRecentVersionApi(guid), Survey.class);
+        return get(clientProvider.getConfig().getSurveyMostRecentVersionApi(guid), Survey.class);
     }
     @Override
     public ResourceList<Survey> getAllSurveysMostRecentlyPublishedVersion() {
         session.checkSignedIn();
-        return get(config.getSurveysPublishedApi(), sType);
+        return get(clientProvider.getConfig().getSurveysPublishedApi(), sType);
     }
     @Override
     public ResourceList<Survey> getAllSurveysMostRecentVersion() {
         session.checkSignedIn();
-        return get(config.getSurveysRecentApi(), sType);
+        return get(clientProvider.getConfig().getSurveysRecentApi(), sType);
     }
     @Override
     public GuidCreatedOnVersionHolder createSurvey(Survey survey) {
         session.checkSignedIn();
         checkNotNull(survey, Bridge.CANNOT_BE_NULL,"Survey object");
-        return post(config.getSurveysApi(), survey, SimpleGuidCreatedOnVersionHolder.class);
+        return post(clientProvider.getConfig().getSurveysApi(), survey, SimpleGuidCreatedOnVersionHolder.class);
     }
     @Override
     public GuidCreatedOnVersionHolder versionSurvey(GuidCreatedOnVersionHolder keys) {
@@ -120,14 +121,15 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
         checkNotNull(keys, Bridge.CANNOT_BE_NULL, "guid/createdOn keys");
         checkArgument(isNotBlank(keys.getGuid()), Bridge.CANNOT_BE_BLANK, "guid");
         checkNotNull(keys.getCreatedOn(), Bridge.CANNOT_BE_NULL, "createdOn");
-        return post(config.getSurveyNewVersionApi(keys.getGuid(), keys.getCreatedOn()), null, SimpleGuidCreatedOnVersionHolder.class);
+        return post(clientProvider.getConfig().getSurveyNewVersionApi(keys.getGuid(), keys.getCreatedOn()), null,
+                SimpleGuidCreatedOnVersionHolder.class);
     }
     @Override
     public GuidCreatedOnVersionHolder updateSurvey(Survey survey) {
         session.checkSignedIn();
         checkNotNull(survey, Bridge.CANNOT_BE_NULL,"Survey object");
-        return post(config.getSurveyApi(survey.getGuid(), new DateTime(survey.getCreatedOn())), survey,
-                SimpleGuidCreatedOnVersionHolder.class);
+        return post(clientProvider.getConfig().getSurveyApi(survey.getGuid(), new DateTime(survey.getCreatedOn())),
+                survey, SimpleGuidCreatedOnVersionHolder.class);
     }
     @Override
     public void publishSurvey(GuidCreatedOnVersionHolder keys) {
@@ -135,7 +137,7 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
         checkNotNull(keys, Bridge.CANNOT_BE_NULL, "guid/createdOn keys");
         checkArgument(isNotBlank(keys.getGuid()), Bridge.CANNOT_BE_BLANK, "guid");
         checkNotNull(keys.getCreatedOn(), Bridge.CANNOT_BE_NULL, "createdOn");
-        post(config.getPublishSurveyApi(keys.getGuid(), keys.getCreatedOn()));
+        post(clientProvider.getConfig().getPublishSurveyApi(keys.getGuid(), keys.getCreatedOn()));
     }
     @Override
     public GuidCreatedOnVersionHolder versionUpdateAndPublishSurvey(Survey survey, boolean publish) {
@@ -157,7 +159,7 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
         checkNotNull(keys, Bridge.CANNOT_BE_NULL, "guid/createdOn keys");
         checkArgument(isNotBlank(keys.getGuid()), Bridge.CANNOT_BE_BLANK, "guid");
         checkNotNull(keys.getCreatedOn(), Bridge.CANNOT_BE_NULL, "createdOn");
-        post(config.getCloseSurveyApi(keys.getGuid(), keys.getCreatedOn()));
+        post(clientProvider.getConfig().getCloseSurveyApi(keys.getGuid(), keys.getCreatedOn()));
     }
     @Override
     public void deleteSurvey(GuidCreatedOnVersionHolder keys) {
@@ -165,41 +167,42 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
         checkNotNull(keys, Bridge.CANNOT_BE_NULL, "guid/createdOn keys");
         checkArgument(isNotBlank(keys.getGuid()), Bridge.CANNOT_BE_BLANK, "guid");
         checkNotNull(keys.getCreatedOn(), Bridge.CANNOT_BE_NULL, "createdOn");
-        delete(config.getSurveyApi(keys.getGuid(), keys.getCreatedOn()));
+        delete(clientProvider.getConfig().getSurveyApi(keys.getGuid(), keys.getCreatedOn()));
     }
     @Override
     public ResourceList<SchedulePlan> getSchedulePlans() {
         session.checkSignedIn();
-        return get(config.getSchedulePlansApi(), spType);
+        return get(clientProvider.getConfig().getSchedulePlansApi(), spType);
     }
     @Override
     public GuidVersionHolder createSchedulePlan(SchedulePlan plan) {
         session.checkSignedIn();
         checkNotNull(plan, Bridge.CANNOT_BE_NULL, "SchedulePlan");
-        return post(config.getSchedulePlansApi(), plan, SimpleGuidVersionHolder.class);
+        return post(clientProvider.getConfig().getSchedulePlansApi(), plan, SimpleGuidVersionHolder.class);
     }
     @Override
     public SchedulePlan getSchedulePlan(String guid) {
         session.checkSignedIn();
         checkArgument(isNotBlank(guid), Bridge.CANNOT_BE_BLANK, "guid");
-        return get(config.getSchedulePlanApi(guid), SchedulePlan.class);
+        return get(clientProvider.getConfig().getSchedulePlanApi(guid), SchedulePlan.class);
     }
     @Override
     public GuidVersionHolder updateSchedulePlan(SchedulePlan plan) {
         session.checkSignedIn();
         checkNotNull(plan, Bridge.CANNOT_BE_NULL, "SchedulePlan");
-        return post(config.getSchedulePlanApi(plan.getGuid()), plan, SimpleGuidVersionHolder.class);
+        return post(clientProvider.getConfig().getSchedulePlanApi(plan.getGuid()), plan,
+                SimpleGuidVersionHolder.class);
     }
     @Override
     public void deleteSchedulePlan(String guid) {
         session.checkSignedIn();
         checkArgument(isNotBlank(guid), Bridge.CANNOT_BE_BLANK, "guid");
-        delete(config.getSchedulePlanApi(guid));
+        delete(clientProvider.getConfig().getSchedulePlanApi(guid));
     }
     @Override
     public Study getStudy() {
         session.checkSignedIn();
-        return get(config.getResearcherStudyApi(), Study.class);
+        return get(clientProvider.getConfig().getResearcherStudyApi(), Study.class);
     }
     @Override
     public VersionHolder updateStudy(Study study) {
@@ -207,6 +210,6 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
         checkNotNull(study, Bridge.CANNOT_BE_NULL, "study");
         checkNotNull(isNotBlank(study.getIdentifier()), Bridge.CANNOT_BE_BLANK, "study identifier");
         
-        return post(config.getResearcherStudyApi(), study, SimpleVersionHolder.class);
+        return post(clientProvider.getConfig().getResearcherStudyApi(), study, SimpleVersionHolder.class);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/ClientInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/ClientInfo.java
@@ -16,14 +16,6 @@ public final class ClientInfo {
     private String osVersion = "";
     private String sdkVersion = "";
 
-    ClientInfo(boolean defaultValues) {
-        if (defaultValues) {
-            osName = System.getProperty("os.name");
-            osVersion = System.getProperty("os.version");
-            sdkVersion = ClientProvider.getConfig().getSdkVersion();
-        }
-    }
-    
     /**
      * The name of the application that is using this SDK to contact the Bridge server.
      * @param appName

--- a/src/main/java/org/sagebionetworks/bridge/sdk/ClientProvider.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/ClientProvider.java
@@ -4,26 +4,65 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.sagebionetworks.bridge.sdk.models.users.ResetPasswordCredentials;
 import org.sagebionetworks.bridge.sdk.models.users.SignInCredentials;
 import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
+/**
+ * Main entry point for Bridge Java SDK.
+ */
 public class ClientProvider {
 
-    private static final Config config = Config.valueOf();
-    
-    private static final ClientInfo info = new ClientInfo(true);
-    
+    private final @Nonnull Config config;
+    private final @Nonnull ClientInfo info;
+    private final BaseApiCaller baseApiCaller = new BaseApiCaller(null, this);
+
+    /**
+     * Default constructor. Constructs a ClientProvider with the default values.
+     */
+    public ClientProvider() {
+        this(null, null);
+    }
+
+    /**
+     * Constructs a ClientProvider with the specified config and client info. If the config or the client info are
+     * specified as null, this constructor uses the default values instead.
+     *
+     * @param config
+     *         client config, uses default configs if null
+     * @param info
+     *         client info, instantiates client info with default values if null
+     */
+    public ClientProvider(@Nullable Config config, @Nullable ClientInfo info) {
+        if (config != null) {
+            this.config = config;
+        } else {
+            this.config = new Config();
+        }
+
+        if (info != null) {
+            this.info = info;
+        } else {
+            this.info = new ClientInfo().withOsName(System.getProperty("os.name"))
+                    .withOsVersion(System.getProperty("os.version")).withSdkVersion(this.config.getSdkVersion());
+        }
+    }
+
     /**
      * Retrieve the Config object for the system.
      *
      * @return Config
      */
-    public static synchronized Config getConfig() {
+    @Nonnull
+    public Config getConfig() {
         return config;
     }
-    
-    public static ClientInfo getClientInfo() {
+
+    @Nonnull
+    public ClientInfo getClientInfo() {
         return info;
     }
 
@@ -34,11 +73,11 @@ public class ClientProvider {
      *            The credentials you wish to sign in with.
      * @return Session
      */
-    public static Session signIn(SignInCredentials signIn) {
+    public Session signIn(SignInCredentials signIn) {
         checkNotNull(signIn, "SignInCredentials required.");
 
-        UserSession session = new BaseApiCaller(null).post(config.getAuthSignInApi(), signIn, UserSession.class);
-        return BridgeSession.valueOf(session);
+        UserSession session = baseApiCaller.post(config.getAuthSignInApi(), signIn, UserSession.class);
+        return new BridgeSession(session, this);
     }
 
     /**
@@ -47,13 +86,13 @@ public class ClientProvider {
      * @param signUp
      *            The credentials to create an account with.
      */
-    public static void signUp(SignUpCredentials signUp) {
+    public void signUp(SignUpCredentials signUp) {
         checkNotNull(signUp, "SignUpCredentials required.");
         checkArgument(isNotBlank(signUp.getEmail()), "Email cannot be blank/null");
         checkArgument(isNotBlank(signUp.getUsername()), "Username cannot be blank/null");
         checkArgument(isNotBlank(signUp.getPassword()), "Password cannot be blank/null");
 
-        new BaseApiCaller(null).post(config.getAuthSignUpApi(), signUp);
+        baseApiCaller.post(config.getAuthSignUpApi(), signUp);
     }
 
     /**
@@ -62,9 +101,9 @@ public class ClientProvider {
      * @param email
      *            Email associated with a Bridge account.
      */
-    public static void requestResetPassword(String email) {
+    public void requestResetPassword(String email) {
         checkArgument(isNotBlank(email), "Email cannot be blank/null");
 
-        new BaseApiCaller(null).post(config.getAuthRequestResetApi(), new ResetPasswordCredentials(email));
+        baseApiCaller.post(config.getAuthRequestResetApi(), new ResetPasswordCredentials(email));
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -73,7 +73,9 @@ public final class Config {
         UPLOAD_COMPLETE_API,
         USER_MANAGEMENT_API,
         USER_MANAGEMENT_CONSENT_API,
-        USER_MANAGEMENT_ALLTESTUSERS_API;
+        USER_MANAGEMENT_ALLTESTUSERS_API,
+        WORKER_EMAIL,
+        WORKER_PASSWORD;
 
         public String getPropertyName() {
             return this.name().replace("_", ".").toLowerCase();
@@ -294,6 +296,15 @@ public final class Config {
     }
     public String getResearcherStudyApi() {
         return val(Props.RESEARCHER_STUDY_API);
+    }
+    public SignInCredentials getWorkerCredentials() {
+        return new SignInCredentials(getWorkerEmail(), getWorkerPassword());
+    }
+    public String getWorkerEmail() {
+        return val(Props.WORKER_EMAIL);
+    }
+    public String getWorkerPassword() {
+        return val(Props.WORKER_PASSWORD);
     }
     public String getAdminStudiesApi() {
         return val(Props.ADMIN_STUDIES_API);

--- a/src/test/java/org/sagebionetworks/bridge/scripts/ScriptUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/scripts/ScriptUtils.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.bridge.sdk.models.surveys.SurveyQuestionOption;
 import com.google.common.collect.Lists;
 
 public class ScriptUtils {
+    private static final ClientProvider CLIENT_PROVIDER = new ClientProvider();
 
     /**
      * If you want to have a question that displays the choices "Yes" and "No", 
@@ -34,7 +35,7 @@ public class ScriptUtils {
         checkNotNull(schedule);
         checkNotNull(guid);
         
-        Config config = ClientProvider.getConfig();
+        Config config = CLIENT_PROVIDER.getConfig();
         String url = config.getHost() + config.getRecentlyPublishedSurveyUserApi(guid);
         
         schedule.addActivity(new Activity("Take survey", ActivityType.survey, url));
@@ -43,7 +44,7 @@ public class ScriptUtils {
         checkNotNull(schedule);
         checkNotNull(keys);
 
-        Config config = ClientProvider.getConfig();
+        Config config = CLIENT_PROVIDER.getConfig();
         String url = config.getHost() + config.getSurveyUserApi(keys.getGuid(), keys.getCreatedOn());
         
         schedule.addActivity(new Activity("Take survey", ActivityType.survey, url));

--- a/src/test/java/org/sagebionetworks/bridge/sdk/ClientInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/ClientInfoTest.java
@@ -11,7 +11,7 @@ public class ClientInfoTest {
     
     @Before
     public void before() {
-        info = new ClientInfo(false); // no default values
+        info = new ClientInfo();
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/sdk/ClientProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/ClientProviderTest.java
@@ -11,6 +11,7 @@ import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.models.users.SignInCredentials;
 
 public class ClientProviderTest {
+    private static final ClientProvider CLIENT_PROVIDER = new ClientProvider();
 
     private TestUser testUser;
     
@@ -29,7 +30,7 @@ public class ClientProviderTest {
         testUser.getSession().signOut();
         
         SignInCredentials credentials = new SignInCredentials(testUser.getUsername(), testUser.getPassword());
-        Session session = ClientProvider.signIn(credentials);
+        Session session = CLIENT_PROVIDER.signIn(credentials);
         assertTrue(session.isSignedIn());
 
         UserClient client = session.getUserClient();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/ConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/ConfigTest.java
@@ -9,14 +9,14 @@ public class ConfigTest {
 
     @Test
     public void createConfig() {
-        Config conf = Config.valueOf();
+        Config conf = new Config();
         assertNotNull(conf);
         assertEquals("conf returns values", "/api/v1/healthdata/asdf", conf.getHealthDataTrackerApi("asdf"));
     }
     
     @Test(expected=IllegalArgumentException.class)
     public void configChecksArguments() {
-        Config conf = Config.valueOf();
+        Config conf = new Config();
         conf.getHealthDataTrackerApi(null);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/sdk/TestUserHelper.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/TestUserHelper.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 import com.google.common.collect.Sets;
 
 public class TestUserHelper {
+    private static final ClientProvider CLIENT_PROVIDER = new ClientProvider();
 
     public static class TestUser {
         private final AdminClient adminClient;
@@ -59,8 +60,8 @@ public class TestUserHelper {
     }
 
     public static TestUser getSignedInAdmin() {
-        Config config = ClientProvider.getConfig();
-        Session session = ClientProvider.signIn(config.getAdminCredentials());
+        Config config = CLIENT_PROVIDER.getConfig();
+        Session session = CLIENT_PROVIDER.signIn(config.getAdminCredentials());
         AdminClient adminClient = session.getAdminClient();
 
         return new TestUserHelper.TestUser(adminClient, session, "", "", "", Sets.newHashSet(Tests.ADMIN_ROLE));
@@ -69,10 +70,10 @@ public class TestUserHelper {
     public static TestUser createAndSignInUser(Class<?> cls, boolean consent, String... roles) {
         checkNotNull(cls);
 
-        ClientProvider.getClientInfo().withAppName("Integration Tests");
+        CLIENT_PROVIDER.getClientInfo().withAppName("Integration Tests");
 
-        Config config = ClientProvider.getConfig();
-        Session session = ClientProvider.signIn(config.getAdminCredentials());
+        Config config = CLIENT_PROVIDER.getConfig();
+        Session session = CLIENT_PROVIDER.signIn(config.getAdminCredentials());
         AdminClient adminClient = session.getAdminClient();
 
         Set<String> rolesList = (roles == null) ? Sets.<String>newHashSet() : Sets.newHashSet(roles);
@@ -87,10 +88,10 @@ public class TestUserHelper {
         SignUpCredentials signUp = new SignUpCredentials(name, emailAddress, "P4ssword");
         adminClient.createUser(signUp, rolesList, consent);
 
-        Session userSession = null;
+        Session userSession;
         try {
             SignInCredentials signIn = new SignInCredentials(name, "P4ssword");
-            userSession = ClientProvider.signIn(signIn);
+            userSession = CLIENT_PROVIDER.signIn(signIn);
         } catch(ConsentRequiredException e) {
             userSession = e.getSession();
             // Do nothing. Some tests want to play around with a user who has not yet consented.
@@ -100,7 +101,7 @@ public class TestUserHelper {
     }
 
     public static String makeUserName(Class<?> cls) {
-        Config config = ClientProvider.getConfig();
+        Config config = CLIENT_PROVIDER.getConfig();
         String devName = config.getDevName();
         String clsPart = cls.getSimpleName();
         String rndPart = RandomStringUtils.randomAlphabetic(4);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
@@ -13,14 +13,15 @@ import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
 public class UserManagementTest {
+    private static final ClientProvider CLIENT_PROVIDER = new ClientProvider();
 
     private Session session;
     private AdminClient admin;
 
     @Before
     public void before() {
-        Config config = ClientProvider.getConfig();
-        session = ClientProvider.signIn(config.getAdminCredentials());
+        Config config = CLIENT_PROVIDER.getConfig();
+        session = CLIENT_PROVIDER.signIn(config.getAdminCredentials());
         admin = session.getAdminClient();
     }
 


### PR DESCRIPTION
The Bridge Worker App should use the Java SDK. First, we need the concept of worker accounts.

We also need to refactor the code to enable the Java SDK to be configured per study and call multiple studies from within the same JVM. This largely entails making ClientProvider and Config instantiable classes instead of static singletons.

Includes the following changes:
- Added configs for worker account.
- Also, fixed bug in Readme for dependencies.
- call multiple studies from the same JVM
- clean up warnings
