### PR TITLE
Adding sharing scope to consent call in SDK

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/BaseApiCaller.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BaseApiCaller.java
@@ -194,6 +194,10 @@ class BaseApiCaller {
             throw new BridgeSDKException(message, e);
         }
     }
+    
+    protected HttpResponse post(String url, JsonNode node) {
+        return postJSON(url, node.toString());
+    }
 
     protected <T> T post(String url, Object object, TypeReference<T> type) {
         try {

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
@@ -30,6 +30,7 @@ import org.sagebionetworks.bridge.sdk.models.users.ConsentSignature;
 import org.sagebionetworks.bridge.sdk.models.users.UserProfile;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class BridgeUserClient extends BaseApiCaller implements UserClient {
 
@@ -63,18 +64,26 @@ class BridgeUserClient extends BaseApiCaller implements UserClient {
      */
 
     @Override
-    public void consentToResearch(ConsentSignature signature) {
+    public void consentToResearch(ConsentSignature signature, SharingScope sharingScope) {
         session.checkSignedIn();
 
         checkNotNull(signature, Bridge.CANNOT_BE_NULL, "ConsentSignature");
-        post(config.getConsentApi(), signature);
+        checkNotNull(sharingScope, Bridge.CANNOT_BE_NULL, "SharingScope");
+        
+        // The JSON sent to the server is unusual because it combines the arguments when submitting, 
+        // but the signature does not include sharing when it is returned from the server.
+        ObjectNode sigJson = Utilities.getMapper().valueToTree(signature);
+        sigJson.put("scope", sharingScope.name());
+        
+        post(config.getConsentPostApi(), sigJson);
         session.setConsented(true);
+        session.setSharingScope(sharingScope);
     }
 
     @Override
     public ConsentSignature getConsentSignature() {
         session.checkSignedIn();
-        ConsentSignature sig = get(config.getConsentApi(), ConsentSignature.class);
+        ConsentSignature sig = get(config.getConsentGetApi(), ConsentSignature.class);
         return sig;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -38,7 +38,8 @@ public final class Config {
         AUTH_VERIFYEMAIL_API,
         AUTH_REQUESTRESET_API,
         AUTH_RESET_API,
-        CONSENT_API,
+        CONSENT_GET_API,
+        CONSENT_POST_API,
         CONSENT_CHANGE_API,
         DEV_NAME,
         ENV,
@@ -184,8 +185,11 @@ public final class Config {
     public String getProfileApi() {
         return val(Props.PROFILE_API);
     }
-    public String getConsentApi() {
-        return val(Props.CONSENT_API);
+    public String getConsentGetApi() {
+        return val(Props.CONSENT_GET_API);
+    }
+    public String getConsentPostApi() {
+        return val(Props.CONSENT_POST_API);
     }
     public String getConsentChangeApi() {
         return val(Props.CONSENT_CHANGE_API);

--- a/src/main/java/org/sagebionetworks/bridge/sdk/SharingScope.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/SharingScope.java
@@ -9,7 +9,7 @@ public enum SharingScope {
      * Only export data for this participant to data sets that are restricted to the original 
      * study researchers and their affiliated research partners.
      */
-    sponsors_and_partners,
+    sponsors_and_partners_only,
     /**
      * Data for this participant can be exported for use by any researcher who qualifies given
      * the governance qualifications of this data set.

--- a/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
@@ -36,8 +36,10 @@ public interface UserClient {
      *
      * @param signature
      *            Name, birthdate, and optionally signature image, of consenter's signature.
+     * @param sharingScope
+     *            The scope of sharing allowed (initially) by this consent.
      */
-    public void consentToResearch(ConsentSignature signature);
+    public void consentToResearch(ConsentSignature signature, SharingScope sharingScope);
 
     /**
      * Returns the user's consent signature, which includes the name, birthdate, and signature image.

--- a/src/main/resources/bridge-sdk.properties
+++ b/src/main/resources/bridge-sdk.properties
@@ -14,7 +14,11 @@ auth.reset.api = /api/v1/auth/resetPassword
 ### User Profile
 profile.api = /api/v1/profile
 ### Consent
-consent.api = /api/v1/consent
+# TODO: Undo this. When we version an endpoint on the server, provide all the
+# verbs for that endpoint. It's very confusing to POST to version 2 and GET 
+# from version 1. But not right before release.
+consent.get.api = /api/v1/consent
+consent.post.api = /api/v2/consent
 consent.change.api = /api/v2/consent/dataSharing
 ### File Upload
 upload.api = /api/v1/upload


### PR DESCRIPTION
It's unfortunate that we get from /api/v1/consent and post to /api/v2/consent, so I'll fix that on the server, but not before release. 
