### PR TITLE
Changing signature of admin create user

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/AdminClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/AdminClient.java
@@ -1,13 +1,10 @@
 package org.sagebionetworks.bridge.sdk;
 
-import java.util.Set;
-
 import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.VersionHolder;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
-import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
 public interface AdminClient {
 
@@ -16,13 +13,9 @@ public interface AdminClient {
      *
      * @param signUp
      *            Credentials used to sign up the user into Bridge.
-     * @param roles
-     *            Roles assigned to the user ("studykey_researcher", "studykey_admin", or null for participants).
-     * @param consent
-     *            Whether the user should be automatically consented upon sign up.
      * @return true if success, false if failure.
      */
-    public boolean createUser(SignUpCredentials signUp, Set<String> roles, boolean consent);
+    public boolean createUser(SignUpByAdmin signUp);
 
     /**
      * Delete a user.

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeAdminClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeAdminClient.java
@@ -5,7 +5,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.http.HttpResponse;
 import org.joda.time.DateTime;
@@ -14,7 +13,6 @@ import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.SimpleVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.VersionHolder;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
-import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -25,10 +23,10 @@ final class BridgeAdminClient extends BaseApiCaller implements AdminClient {
     }
 
     @Override
-    public boolean createUser(SignUpCredentials signUp, Set<String> roles, boolean consent) {
+    public boolean createUser(SignUpByAdmin signUp) {
         session.checkSignedIn();
 
-        HttpResponse response = post(config.getUserManagementApi(), new AdminSignUpCredentials(signUp, roles, consent));
+        HttpResponse response = post(config.getUserManagementApi(), signUp);
         return response.getStatusLine().getStatusCode() == 201;
     }
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/sdk/SignUpByAdmin.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/SignUpByAdmin.java
@@ -1,23 +1,29 @@
 package org.sagebionetworks.bridge.sdk;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.Set;
 
-import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
-
-class AdminSignUpCredentials {
+public class SignUpByAdmin {
+    
     private final String username;
     private final String email;
     private final String password;
     private final Set<String> roles;
     private final boolean consent;
 
-    public AdminSignUpCredentials(SignUpCredentials signUp, Set<String> roles, boolean consent) {
-        this.username = signUp.getUsername();
-        this.email = signUp.getEmail();
-        this.password = signUp.getPassword();
+    public SignUpByAdmin(String username, String email, String password, Set<String> roles, boolean consent) {
+        checkArgument(isNotBlank(username));
+        checkArgument(isNotBlank(email));
+        checkArgument(isNotBlank(password));
+        this.username = username;
+        this.email = email;
+        this.password = password;
         this.roles = roles;
         this.consent = consent;
     }
+    
     public String getUsername() {
         return username;
     }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/TestUserHelper.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/TestUserHelper.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.sagebionetworks.bridge.Tests;
 import org.sagebionetworks.bridge.sdk.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.sdk.models.users.SignInCredentials;
-import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
 import com.google.common.collect.Sets;
 
@@ -82,10 +81,10 @@ public class TestUserHelper {
         // For email address, we don't want consent emails to bounce or SES will get mad at us. All test user email
         // addresses should be in the form bridge-testing+[semi-unique token]@sagebase.org. This directs all test
         // email to bridge-testing@sagebase.org.
-        String emailAddress = String.format("bridge-testing+%s@sagebase.org", name);
+        String emailAddress = makeEmail(name);
 
-        SignUpCredentials signUp = new SignUpCredentials(Tests.TEST_KEY, name, emailAddress, "P4ssword");
-        adminClient.createUser(signUp, rolesList, consent);
+        SignUpByAdmin signUp = new SignUpByAdmin(name, emailAddress, "P4ssword", rolesList, consent);
+        adminClient.createUser(signUp);
 
         Session userSession = null;
         try {
@@ -105,5 +104,9 @@ public class TestUserHelper {
         String clsPart = cls.getSimpleName();
         String rndPart = RandomStringUtils.randomAlphabetic(4);
         return String.format("%s-%s-%s", devName, clsPart, rndPart);
+    }
+    
+    public static String makeEmail(String userName) {
+        return String.format("bridge-testing+%s@sagebase.org", userName);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserManagementTest.java
@@ -5,13 +5,12 @@ import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.sagebionetworks.bridge.Tests;
 import org.sagebionetworks.bridge.sdk.AdminClient;
+import org.sagebionetworks.bridge.sdk.SignUpByAdmin;
 import org.sagebionetworks.bridge.sdk.ClientProvider;
 import org.sagebionetworks.bridge.sdk.Config;
 import org.sagebionetworks.bridge.sdk.Session;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
-import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
 public class UserManagementTest {
 
@@ -37,9 +36,9 @@ public class UserManagementTest {
         String password = "P4ssword";
         boolean consent = true;
 
-        SignUpCredentials signUp = new SignUpCredentials(Tests.TEST_KEY, username, email, password);
+        SignUpByAdmin signUp = new SignUpByAdmin(username, email, password, null, consent);
 
-        boolean result = admin.createUser(signUp, null, consent);
+        boolean result = admin.createUser(signUp);
         assertTrue(result);
 
         // This is already done as part of deletion, and doesn't make sense separately because we're not


### PR DESCRIPTION
The admin method to create a user re-used an object that allowed you to set a study identifier, suggesting that an admin in study A could create a user in study B. That's actually not true. These changes make sure that you have no way to set a study when you create a user this way, for clarity.

(Users are created in the same study as the admin. Admins are scoped to studies now, like everyone else.)
