### PR TITLE
Upload Schema delete APIs and Integration Tests

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
@@ -243,6 +243,21 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
     }
 
     @Override
+    public void deleteUploadSchemaById(String schemaId) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(schemaId), Bridge.CANNOT_BE_BLANK, "schemaId");
+        delete(config.getUploadSchemaByIdApi(schemaId));
+    }
+
+    @Override
+    public void deleteUploadSchemaByIdAndRevision(String schemaId, int revision) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(schemaId), Bridge.CANNOT_BE_BLANK, "schemaId");
+        checkArgument(revision > 0, "revision must be positive");
+        delete(config.getUploadSchemaByIdAndRevisionApi(schemaId, revision));
+    }
+
+    @Override
     public UploadSchema getUploadSchemaById(String schemaId) {
         session.checkSignedIn();
         checkArgument(isNotBlank(schemaId), Bridge.CANNOT_BE_BLANK, "schemaId");

--- a/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -75,6 +75,7 @@ public final class Config {
         UPLOAD_STATUS_API,
         UPLOADSCHEMA_API,
         UPLOADSCHEMA_BY_ID_API,
+        UPLOADSCHEMA_BY_ID_AND_REV_API,
         UPLOADSCHEMA_FOR_STUDY_API,
         USER_MANAGEMENT_API,
         USER_MANAGEMENT_CONSENT_API,
@@ -316,6 +317,10 @@ public final class Config {
 
     public String getUploadSchemaByIdApi(String schemaId) {
         return String.format(val(Props.UPLOADSCHEMA_BY_ID_API), schemaId);
+    }
+
+    public String getUploadSchemaByIdAndRevisionApi(String schemaId, int revision) {
+        return String.format(val(Props.UPLOADSCHEMA_BY_ID_AND_REV_API), schemaId, revision);
     }
 
     public String getUploadSchemaForStudyApi() {

--- a/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
@@ -267,6 +267,26 @@ public interface ResearcherClient {
     public UploadSchema createOrUpdateUploadSchema(UploadSchema schema);
 
     /**
+     * This method deletes all revisions of the upload schema with the specified schema ID. If there are no schemas
+     * with this schema ID, this method throws an EntityNotFoundException.
+     *
+     * @param schemaId
+     *         schema ID of the upload schemas to delete, must be non-null and non-empty
+     */
+    public void deleteUploadSchemaById(String schemaId);
+
+    /**
+     * This method deletes an upload schema with the specified schema ID and revision. If the schema doesn't exist,
+     * this method throws an EntityNotFoundException.
+     *
+     * @param schemaId
+     *         schema ID of the upload schema to delete
+     * @param revision
+     *         revision number of the upload schema to delete, must be positive
+     */
+    public void deleteUploadSchemaByIdAndRevision(String schemaId, int revision);
+
+    /**
      * This method fetches an upload schema from the current study with the specified schema ID. If there is more than
      * one revision of the schema, this fetches the latest revision. If the schema doesn't exist, this method throws an
      * EntityNotFoundException.

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchema.java
@@ -110,6 +110,19 @@ public final class UploadSchema {
         private Integer revision;
         private String schemaId;
 
+        /**
+         * Sets all builder fields to be a copy of the specified schema. This returns the builder, which can be used to
+         * make additional changes to the schema being built. This is commonly used for updating a schema from a
+         * pre-existing one.
+         */
+        public Builder copyOf(UploadSchema other) {
+            this.fieldDefinitions = other.fieldDefinitions;
+            this.name = other.name;
+            this.revision = other.revision;
+            this.schemaId = other.schemaId;
+            return this;
+        }
+
         /** @see org.sagebionetworks.bridge.sdk.models.upload.UploadSchema#getFieldDefinitions */
         public List<UploadFieldDefinition> getFieldDefinitions() {
             return fieldDefinitions;

--- a/src/main/resources/bridge-sdk.properties
+++ b/src/main/resources/bridge-sdk.properties
@@ -48,6 +48,7 @@ survey.close.api = /researchers/v1/surveys/%s/%s/close
 ### Upload Schemas
 uploadschema.api = /researcher/v1/uploadSchema
 uploadschema.by.id.api = /researcher/v1/uploadSchema/byId/%s
+uploadschema.by.id.and.rev.api = /researcher/v1/uploadSchema/byIdAndRev/%s/%d
 uploadschema.for.study.api = /researcher/v1/uploadSchema/forStudy
 
 # Studies

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -3,13 +3,14 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.util.List;
-
-import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.Tests;
 import org.sagebionetworks.bridge.sdk.ResearcherClient;
@@ -22,8 +23,9 @@ import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 public class UploadSchemaTest {
-    private static final String TEST_SCHEMA_ID = "integration-test-schema";
-    private static final String TEST_SCHEMA_NAME = "Upload Schema Integration Tests";
+    private static final Logger LOG = LoggerFactory.getLogger(UploadSchemaTest.class);
+
+    private static final String TEST_SCHEMA_ID_PREFIX = "integration-test-schema-";
 
     private static TestUserHelper.TestUser researcher;
     private static TestUserHelper.TestUser user;
@@ -51,56 +53,96 @@ public class UploadSchemaTest {
     @Test
     public void test() {
         ResearcherClient researcherClient = researcher.getSession().getResearcherClient();
+        String schemaId = TEST_SCHEMA_ID_PREFIX + RandomStringUtils.randomAlphabetic(4);
+        LOG.info("schemaId=" + schemaId);
 
-        // TODO: Don't update the schema until we have a delete API. This will prevent the integration tests from
-        // creating an explosion of schemas. Once we do that, we can do more in-depth testing of these APIs.
+        // set up some field defs
+        UploadFieldDefinition fooFieldDef = new UploadFieldDefinition.Builder().withName("foo").withRequired(true)
+                .withType(UploadFieldType.STRING).build();
+        UploadFieldDefinition barFieldDef = new UploadFieldDefinition.Builder().withName("bar").withRequired(false)
+                .withType(UploadFieldType.INT).build();
+        UploadFieldDefinition bazFieldDef = new UploadFieldDefinition.Builder().withName("baz").withRequired(true)
+                .withType(UploadFieldType.BOOLEAN).build();
 
-        // Step 1: check if the integration test schema already exists
-        boolean foundSchema;
-        try {
-            UploadSchema schema = researcherClient.getUploadSchemaById(TEST_SCHEMA_ID);
-            assertNotNull(schema);
-            foundSchema = true;
-        } catch (EntityNotFoundException ex) {
-            foundSchema = false;
-        }
+        // Step 1: Create initial version of schema.
+        UploadSchema schemaV1 = new UploadSchema.Builder().withFieldDefinitions(fooFieldDef)
+                .withName("Upload Schema Integration Tests").withSchemaId(schemaId).build();
+        UploadSchema createdSchemaV1 = createOrUpdateSchemaAndVerify(schemaV1);
 
-        if (!foundSchema) {
-            // Step 2: Schema doesn't exist, so create it.
-            List<UploadFieldDefinition> submittedFieldDefList = ImmutableList.of(
-                    new UploadFieldDefinition.Builder().withName("foo").withRequired(true)
-                            .withType(UploadFieldType.STRING).build(),
-                    new UploadFieldDefinition.Builder().withName("bar").withRequired(false)
-                            .withType(UploadFieldType.INT).build());
-            UploadSchema submittedSchema = new UploadSchema.Builder().withName(TEST_SCHEMA_NAME)
-                    .withSchemaId(TEST_SCHEMA_ID).withFieldDefinitions(submittedFieldDefList).build();
-            UploadSchema createdSchema = researcherClient.createOrUpdateUploadSchema(submittedSchema);
+        // Step 2: Update to v2
+        UploadSchema schemaV2 = new UploadSchema.Builder().copyOf(createdSchemaV1)
+                .withFieldDefinitions(fooFieldDef, barFieldDef).withName("Schema Test II: The Sequel").build();
+        UploadSchema updatedSchemaV2 = createOrUpdateSchemaAndVerify(schemaV2);
 
-            assertEquals(TEST_SCHEMA_NAME, createdSchema.getName());
-            assertEquals(1, createdSchema.getRevision().intValue());
-            assertEquals(TEST_SCHEMA_ID, createdSchema.getSchemaId());
-            assertEquals(submittedFieldDefList, createdSchema.getFieldDefinitions());
+        // Step 3: Another update. Having multiple versions helps test the delete API.
+        UploadSchema schemaV3 = new UploadSchema.Builder().copyOf(updatedSchemaV2)
+                .withFieldDefinitions(fooFieldDef, barFieldDef, bazFieldDef).withName("Schema Test v3").build();
+        createOrUpdateSchemaAndVerify(schemaV3);
 
-            // Step 3: test the getUploadSchemaById() method, by getting the same schema back from the server and
-            // comparing for equality
-            UploadSchema returnedSchema = researcherClient.getUploadSchemaById(TEST_SCHEMA_ID);
-            assertEquals(createdSchema, returnedSchema);
-        }
+        // Step 4: Delete v3 and verify the getter returns v2.
+        researcherClient.deleteUploadSchemaByIdAndRevision(schemaId, 3);
+        UploadSchema returnedAfterDelete = researcherClient.getUploadSchemaById(schemaId);
+        assertEquals(updatedSchemaV2, returnedAfterDelete);
 
-        // Step 4: List schemas. The schema may have been created by a previous version of the integration tests, so
-        // the only thing we know for sure is that it has the same Schema ID. Iterate through all the schemas until
-        // you find it.
-        //
-        // We do this instead of just calling getById because we want to test the list API.
-        boolean foundListedSchema = false;
+        // Step 4a: Use list API to verify v1 and v2 are both still present
+        boolean v1Found = false;
+        boolean v2Found = false;
         ResourceList<UploadSchema> schemaList = researcherClient.getUploadSchemaForStudy();
-        for (UploadSchema oneListedSchema : schemaList) {
-            if (TEST_SCHEMA_ID.equals(oneListedSchema.getSchemaId())) {
-                foundListedSchema = true;
-                break;
+        for (UploadSchema oneSchema : schemaList) {
+            if (oneSchema.getSchemaId().equals(schemaId)) {
+                int rev = oneSchema.getRevision();
+                if (rev == 1) {
+                    assertEquals(createdSchemaV1, oneSchema);
+                    v1Found = true;
+                } else if (rev == 2) {
+                    assertEquals(updatedSchemaV2, oneSchema);
+                    v2Found = true;
+                } else {
+                    fail("Unexpected schema revision: " + rev);
+                }
             }
         }
-        assertTrue(foundListedSchema);
+        assertTrue(v1Found);
+        assertTrue(v2Found);
+
+        // Step 5: Delete all schemas with the test schema ID
+        researcherClient.deleteUploadSchemaById(schemaId);
+
+        // Step 5a: Get API should throw
+        Exception thrownEx = null;
+        try {
+            researcherClient.getUploadSchemaById(schemaId);
+            fail("expected exception");
+        } catch (EntityNotFoundException ex) {
+            thrownEx = ex;
+        }
+        assertNotNull(thrownEx);
+
+        // Step 5b: Use list API to verify no schemas with this ID
+        ResourceList<UploadSchema> schemaList2 = researcherClient.getUploadSchemaForStudy();
+        for (UploadSchema oneSchema : schemaList2) {
+            if (oneSchema.getSchemaId().equals(schemaId)) {
+                fail("Found schema with ID " + schemaId + " even though it should have been deleted");
+            }
+        }
+    }
+
+    private static UploadSchema createOrUpdateSchemaAndVerify(UploadSchema schema) {
+        ResearcherClient researcherClient = researcher.getSession().getResearcherClient();
+        UploadSchema returnedSchema = researcherClient.createOrUpdateUploadSchema(schema);
+
+        // all fields should match, except revision which is incremented
+        assertEquals(schema.getFieldDefinitions(), returnedSchema.getFieldDefinitions());
+        assertEquals(schema.getName(), returnedSchema.getName());
+        assertEquals(schema.getSchemaId(), returnedSchema.getSchemaId());
+
+        if (schema.getRevision() == null) {
+            assertEquals(1, returnedSchema.getRevision().intValue());
+        } else {
+            assertEquals(schema.getRevision() + 1, returnedSchema.getRevision().intValue());
+        }
+
+        return returnedSchema;
     }
 
     @Test(expected=UnauthorizedException.class)

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaTest.java
@@ -122,9 +122,9 @@ public class UploadSchemaTest {
     @Test
     public void fieldDefVarargs() {
         UploadSchema testSchema = new UploadSchema.Builder().withFieldDefinitions(
-                    new UploadFieldDefinition("foo", UploadFieldType.STRING),
-                    new UploadFieldDefinition("bar", UploadFieldType.BOOLEAN),
-                    new UploadFieldDefinition("baz", UploadFieldType.INT))
+                new UploadFieldDefinition("foo", UploadFieldType.STRING),
+                new UploadFieldDefinition("bar", UploadFieldType.BOOLEAN),
+                new UploadFieldDefinition("baz", UploadFieldType.INT))
                 .withName("Field Def Varargs Schema").withSchemaId("field-def-varargs-schema").build();
         assertEquals("Field Def Varargs Schema", testSchema.getName());
         assertNull(testSchema.getRevision());
@@ -136,6 +136,14 @@ public class UploadSchemaTest {
         assertEquals("foo", outputFieldDefList.get(0).getName());
         assertEquals("bar", outputFieldDefList.get(1).getName());
         assertEquals("baz", outputFieldDefList.get(2).getName());
+    }
+
+    @Test
+    public void builderCopyOf() {
+        UploadSchema originalSchema = new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList())
+                .withName("Copied Schema").withRevision(1).withSchemaId("copied-schema").build();
+        UploadSchema copiedSchema = new UploadSchema.Builder().copyOf(originalSchema).build();
+        assertEquals(originalSchema, copiedSchema);
     }
 
     @Test


### PR DESCRIPTION
The delete APIs allow the integration tests to create and update schemas and clean after themselves. This allows for more extensive testing. This was tested in devo, staging, and prod.
