### PR TITLE
fix local integration tests - fixed missed MD5 change in UploadRequestTest

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/UploadRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/UploadRequestTest.java
@@ -97,7 +97,7 @@ public class UploadRequestTest {
         UploadRequest req = new UploadRequest.Builder().withFile(file).withContentType("application/zip").build();
         assertEquals("non-json-encrypted", req.getName());
         assertEquals(1231, req.getContentLength());
-        assertEquals("rvEOqlhktlOk+7sKG/Euvg==", req.getContentMd5());
+        assertEquals("sb9igDhUaTSURFMyVRdmDA==", req.getContentMd5());
         assertEquals("application/zip", req.getContentType());
     }
 


### PR DESCRIPTION
Re-generated the local upload test files in https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/128, but missed a change in UploadRequestTest
