### PR TITLE
Most recent survey for user

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
@@ -171,14 +171,6 @@ class BridgeUserClient extends BaseApiCaller implements UserClient {
         post(config.getSurveyResponseApi(response.getIdentifier()), answers);
     }
 
-    @Override
-    public void deleteSurveyResponse(String identifier) {
-        session.checkSignedIn();
-        checkNotNull(isNotBlank(identifier), "Survey response identifier cannot be null or blank.");
-
-        delete(config.getSurveyResponseApi(identifier));
-    }
-
     /*
      * Upload API
      */

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
@@ -126,6 +126,14 @@ class BridgeUserClient extends BaseApiCaller implements UserClient {
     }
     
     @Override
+    public Survey getSurveyMostRecent(String guid) {
+        session.checkSignedIn();
+        checkNotNull(guid, Bridge.CANNOT_BE_NULL, "guid");
+        
+        return get(config.getRecentlyPublishedSurveyUserApi(guid), Survey.class);
+    }
+    
+    @Override
     public IdentifierHolder submitAnswersToSurvey(GuidCreatedOnVersionHolder keys, List<SurveyAnswer> answers) {
         session.checkSignedIn();
         checkNotNull(keys, "Survey keys cannot be null.");

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeUserClient.java
@@ -126,7 +126,7 @@ class BridgeUserClient extends BaseApiCaller implements UserClient {
     }
     
     @Override
-    public Survey getSurveyMostRecent(String guid) {
+    public Survey getSurveyMostRecentlyPublished(String guid) {
         session.checkSignedIn();
         checkNotNull(guid, Bridge.CANNOT_BE_NULL, "guid");
         

--- a/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
@@ -91,7 +91,7 @@ public interface UserClient {
      * @param guid
      * @return
      */
-    public Survey getSurveyMostRecent(String guid);
+    public Survey getSurveyMostRecentlyPublished(String guid);
     
     /**
      * Submit a list of SurveyAnswers to a particular survey.

--- a/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
@@ -87,9 +87,10 @@ public interface UserClient {
     public Survey getSurvey(GuidCreatedOnVersionHolder keys);
     
     /**
-     * Get the most recently published survey available for the provided guid.
+     * Get the most recently published survey available for the provided survey GUID.
      * @param guid
-     * @return
+     * 
+     * @return Survey
      */
     public Survey getSurveyMostRecentlyPublished(String guid);
     

--- a/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
@@ -141,14 +141,6 @@ public interface UserClient {
     public void addAnswersToResponse(SurveyResponse response, List<SurveyAnswer> answers);
 
     /**
-     * Delete a particular survey response.
-     *
-     * @param identifier
-     *            The identifier of the survey response to delete.
-     */
-    public void deleteSurveyResponse(String identifier);
-
-    /**
      * Request an upload session from the user.
      *
      * @param request

--- a/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
@@ -87,6 +87,13 @@ public interface UserClient {
     public Survey getSurvey(GuidCreatedOnVersionHolder keys);
     
     /**
+     * Get the most recently published survey available for the provided guid.
+     * @param guid
+     * @return
+     */
+    public Survey getSurveyMostRecent(String guid);
+    
+    /**
      * Submit a list of SurveyAnswers to a particular survey.
      *
      * @param keys

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -98,7 +98,7 @@ public class SurveyTest {
         client.publishSurvey(key);
         
         UserClient userClient = user.getSession().getUserClient();
-        survey = userClient.getSurveyMostRecent(key.getGuid());
+        survey = userClient.getSurveyMostRecentlyPublished(key.getGuid());
         // And again, correct
         questions = survey.getElements();
         prompt = ((SurveyQuestion)questions.get(1)).getPrompt();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.sdk.ResearcherClient;
 import org.sagebionetworks.bridge.sdk.TestSurvey;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
+import org.sagebionetworks.bridge.sdk.UserClient;
 import org.sagebionetworks.bridge.sdk.exceptions.PublishedSurveyException;
 import org.sagebionetworks.bridge.sdk.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
@@ -93,6 +94,14 @@ public class SurveyTest {
 
         List<SurveyElement> questions = survey.getElements();
         String prompt = ((SurveyQuestion)questions.get(1)).getPrompt();
+        assertEquals("Prompt is correct.", "When did you last have a medical check-up?", prompt);
+        client.publishSurvey(key);
+        
+        UserClient userClient = user.getSession().getUserClient();
+        survey = userClient.getSurveyMostRecent(key.getGuid());
+        // And again, correct
+        questions = survey.getElements();
+        prompt = ((SurveyQuestion)questions.get(1)).getPrompt();
         assertEquals("Prompt is correct.", "When did you last have a medical check-up?", prompt);
     }
 


### PR DESCRIPTION
Adding this method the user client, because that's something a user application would want to do. Matches the fact that activities can have URLs that point to the most recently published version of a survey, regardless of its timestamp.
