### PR TITLE
add schema type to upload schemas, add survey schema to upload integration test bootstrap

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchema.java
@@ -22,14 +22,16 @@ public final class UploadSchema {
     private final String name;
     private final Integer revision;
     private final String schemaId;
+    private final UploadSchemaType schemaType;
 
     /** Private constructor. Construction of an UploadSchema should go through the Builder. */
     private UploadSchema(List<UploadFieldDefinition> fieldDefinitions, String name, Integer revision,
-            String schemaId) {
+            String schemaId, UploadSchemaType schemaType) {
         this.fieldDefinitions = fieldDefinitions;
         this.name = name;
         this.revision = revision;
         this.schemaId = schemaId;
+        this.schemaType = schemaType;
     }
 
     /**
@@ -73,6 +75,11 @@ public final class UploadSchema {
         return schemaId;
     }
 
+    /** Schema type, for example survey vs data. */
+    public UploadSchemaType getSchemaType() {
+        return schemaType;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -81,6 +88,7 @@ public final class UploadSchema {
         result = prime * result + Objects.hashCode(name);
         result = prime * result + Objects.hashCode(revision);
         result = prime * result + Objects.hashCode(schemaId);
+        result = prime * result + Objects.hashCode(schemaType);
         return result;
     }
 
@@ -94,13 +102,14 @@ public final class UploadSchema {
         }
         UploadSchema other = (UploadSchema) obj;
         return Objects.equals(fieldDefinitions, other.fieldDefinitions) && Objects.equals(name, other.name)
-                && Objects.equals(revision, other.revision) && Objects.equals(schemaId, other.schemaId);
+                && Objects.equals(revision, other.revision) && Objects.equals(schemaId, other.schemaId)
+                && Objects.equals(this.schemaType, other.schemaType);
     }
 
     @Override
     public String toString() {
-        return String.format("UploadSchema[name=%s, revision=%s, schemaId=%s, fieldDefinitions=[%s]]", name, revision,
-                schemaId, Joiner.on(", ").join(fieldDefinitions));
+        return String.format("UploadSchema[name=%s, revision=%s, schemaId=%s, schemaType=%s, fieldDefinitions=[%s]]",
+                name, revision, schemaId, schemaType.name(), Joiner.on(", ").join(fieldDefinitions));
     }
 
     /** Builder for UploadSchema */
@@ -109,6 +118,7 @@ public final class UploadSchema {
         private String name;
         private Integer revision;
         private String schemaId;
+        private UploadSchemaType schemaType;
 
         /**
          * Sets all builder fields to be a copy of the specified schema. This returns the builder, which can be used to
@@ -120,6 +130,7 @@ public final class UploadSchema {
             this.name = other.name;
             this.revision = other.revision;
             this.schemaId = other.schemaId;
+            this.schemaType = other.schemaType;
             return this;
         }
 
@@ -175,6 +186,17 @@ public final class UploadSchema {
             return this;
         }
 
+        /** @see org.sagebionetworks.bridge.sdk.models.upload.UploadSchema#getSchemaType */
+        public UploadSchemaType getSchemaType() {
+            return schemaType;
+        }
+
+        /** @see org.sagebionetworks.bridge.sdk.models.upload.UploadSchema#getSchemaType */
+        public Builder withSchemaType(UploadSchemaType schemaType) {
+            this.schemaType = schemaType;
+            return this;
+        }
+
         /**
          * <p>
          * Builds and validates an UploadSchema. This will throw a InvalidEntityException under the following conditions:
@@ -184,6 +206,7 @@ public final class UploadSchema {
          *     <li>name is null or empty</li>
          *     <li>revision is negative</li>
          *     <li>schemaId is null or empty</li>
+         *     <li>schemaType is null</li>
          *   </ul>
          * </p>
          * <p>
@@ -221,7 +244,12 @@ public final class UploadSchema {
                 throw new InvalidEntityException("schemaId cannot be blank");
             }
 
-            return new UploadSchema(ImmutableList.copyOf(fieldDefinitions), name, revision, schemaId);
+            // schema type
+            if (schemaType == null) {
+                throw new InvalidEntityException("schemaType cannot be null");
+            }
+
+            return new UploadSchema(ImmutableList.copyOf(fieldDefinitions), name, revision, schemaId, schemaType);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaType.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaType.java
@@ -1,0 +1,14 @@
+package org.sagebionetworks.bridge.sdk.models.upload;
+
+/**
+ * Tags schemas with the schema type, so we can figure out how to parse the data into the specified fields. Currently,
+ * this only contains iOS-specific schema types. As we define new data formats, we will need to expand this enum. For
+ * more information, see https://sagebionetworks.jira.com/wiki/display/BRIDGE/Bridge+Upload+Data+Format
+ */
+public enum UploadSchemaType {
+    /** iOS data upload. For example, Parkinson's Tapping Activity. */
+    IOS_DATA,
+
+    /** iOS survey. For example, Asthma Weekly Prompt. */
+    IOS_SURVEY,
+}

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadSchemaTest.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchemaType;
 
 public class UploadSchemaTest {
     private static final Logger LOG = LoggerFactory.getLogger(UploadSchemaTest.class);
@@ -66,7 +67,8 @@ public class UploadSchemaTest {
 
         // Step 1: Create initial version of schema.
         UploadSchema schemaV1 = new UploadSchema.Builder().withFieldDefinitions(fooFieldDef)
-                .withName("Upload Schema Integration Tests").withSchemaId(schemaId).build();
+                .withName("Upload Schema Integration Tests").withSchemaId(schemaId)
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
         UploadSchema createdSchemaV1 = createOrUpdateSchemaAndVerify(schemaV1);
 
         // Step 2: Update to v2
@@ -135,6 +137,7 @@ public class UploadSchemaTest {
         assertEquals(schema.getFieldDefinitions(), returnedSchema.getFieldDefinitions());
         assertEquals(schema.getName(), returnedSchema.getName());
         assertEquals(schema.getSchemaId(), returnedSchema.getSchemaId());
+        assertEquals(schema.getSchemaType(), returnedSchema.getSchemaType());
 
         if (schema.getRevision() == null) {
             assertEquals(1, returnedSchema.getRevision().intValue());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UploadTest.java
@@ -27,6 +27,7 @@ import org.sagebionetworks.bridge.sdk.models.UploadSession;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchemaType;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadStatus;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadValidationStatus;
 
@@ -64,12 +65,31 @@ public class UploadTest {
             iosSurveySchema = new UploadSchema.Builder()
                     .withSchemaId("ios-survey")
                     .withName("iOS Survey Response")
+                    .withSchemaType(UploadSchemaType.IOS_DATA)
                     .withFieldDefinitions(
                             new UploadFieldDefinition("answers", UploadFieldType.ATTACHMENT_JSON_TABLE),
                             new UploadFieldDefinition("item", UploadFieldType.STRING),
                             new UploadFieldDefinition("taskRunId", UploadFieldType.STRING))
                     .build();
             researcherClient.createOrUpdateUploadSchema(iosSurveySchema);
+        }
+
+        UploadSchema uploadTestSurveySchema = null;
+        try {
+            uploadTestSurveySchema = researcherClient.getUploadSchema("upload-test-ios-survey");
+        } catch (EntityNotFoundException ex) {
+            // no-op
+        }
+        if (uploadTestSurveySchema == null) {
+            uploadTestSurveySchema = new UploadSchema.Builder()
+                    .withSchemaId("upload-test-ios-survey")
+                    .withName("Upload Test iOS Survey")
+                    .withSchemaType(UploadSchemaType.IOS_SURVEY)
+                    .withFieldDefinitions(
+                            new UploadFieldDefinition("foo", UploadFieldType.STRING),
+                            new UploadFieldDefinition("bar", UploadFieldType.INT))
+                    .build();
+            researcherClient.createOrUpdateUploadSchema(uploadTestSurveySchema);
         }
 
         UploadSchema jsonDataSchema = null;
@@ -82,6 +102,7 @@ public class UploadTest {
             jsonDataSchema = new UploadSchema.Builder()
                     .withSchemaId("upload-test-json-data")
                     .withName("Upload Test JSON Data")
+                    .withSchemaType(UploadSchemaType.IOS_DATA)
                     .withFieldDefinitions(
                             new UploadFieldDefinition("string.json.string", UploadFieldType.STRING),
                             new UploadFieldDefinition("blob.json.blob", UploadFieldType.ATTACHMENT_JSON_BLOB))
@@ -98,9 +119,8 @@ public class UploadTest {
         if (nonJsonSchema == null) {
             nonJsonSchema = new UploadSchema.Builder()
                     .withSchemaId("upload-test-non-json")
-                    // in the current version, non-JSON data matches by name, not by ID, so for testing purposes,
-                    // keep schema and name the same
                     .withName("upload-test-non-json")
+                    .withSchemaType(UploadSchemaType.IOS_DATA)
                     .withFieldDefinitions(
                             new UploadFieldDefinition("nonJson.txt", UploadFieldType.ATTACHMENT_BLOB),
                             new UploadFieldDefinition("jsonFile.json", UploadFieldType.ATTACHMENT_JSON_BLOB))

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaTest.java
@@ -18,68 +18,80 @@ import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 public class UploadSchemaTest {
     @Test(expected = InvalidEntityException.class)
     public void nullFieldDefList() {
-        new UploadSchema.Builder().withName("Test Schema").withSchemaId("test-schema").build();
+        new UploadSchema.Builder().withName("Test Schema").withSchemaId("test-schema")
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void emptyFieldDefList() {
         new UploadSchema.Builder().withFieldDefinitions(ImmutableList.<UploadFieldDefinition>of())
-                .withName("Test Schema").withSchemaId("test-schema").build();
+                .withName("Test Schema").withSchemaId("test-schema").withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void emptyFieldDefVarargs() {
-        new UploadSchema.Builder().withFieldDefinitions().withName("Test Schema").withSchemaId("test-schema").build();
+        new UploadSchema.Builder().withFieldDefinitions().withName("Test Schema").withSchemaId("test-schema")
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void nullName() {
-        new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withSchemaId("test-schema").build();
+        new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withSchemaId("test-schema")
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void emptyName() {
         new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("").withSchemaId("test-schema")
-                .build();
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void blankName() {
         new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("   ")
-                .withSchemaId("test-schema").build();
+                .withSchemaId("test-schema").withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void negativeRevision() {
         new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("Test Schema").withRevision(-1)
-                .withSchemaId("test-schema").build();
+                .withSchemaId("test-schema").withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void nullSchemaId() {
-        new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("Test Schema").build();
+        new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("Test Schema")
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void emptySchemaId() {
         new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("Test Schema").withSchemaId("")
-                .build();
+                .withSchemaType(UploadSchemaType.IOS_DATA).build();
     }
 
     @Test(expected = InvalidEntityException.class)
     public void blankSchemaId() {
         new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("Test Schema")
-                .withSchemaId("   ").build();
+                .withSchemaId("   ").withSchemaType(UploadSchemaType.IOS_DATA).build();
+    }
+
+    @Test(expected = InvalidEntityException.class)
+    public void nullSchemaType() {
+        new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList()).withName("Test Schema")
+                .withSchemaId("test-schema").build();
     }
 
     @Test
     public void happyCase() {
         List<UploadFieldDefinition> inputFieldDefList = mutableFieldDefList();
         UploadSchema testSchema = new UploadSchema.Builder().withFieldDefinitions(inputFieldDefList)
-                .withName("Happy Case Schema").withSchemaId("happy-schema").build();
+                .withName("Happy Case Schema").withSchemaId("happy-schema").withSchemaType(UploadSchemaType.IOS_DATA)
+                .build();
         assertEquals("Happy Case Schema", testSchema.getName());
         assertNull(testSchema.getRevision());
         assertEquals("happy-schema", testSchema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_DATA, testSchema.getSchemaType());
 
         // only check the field name, since everything else is tested by UploadFieldDefinitionTest
         List<UploadFieldDefinition> outputFieldDefList = testSchema.getFieldDefinitions();
@@ -94,10 +106,12 @@ public class UploadSchemaTest {
     @Test
     public void zeroRevision() {
         UploadSchema testSchema = new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList())
-                .withName("Zero Revision Schema").withRevision(0).withSchemaId("zero-revision-schema").build();
+                .withName("Zero Revision Schema").withRevision(0).withSchemaId("zero-revision-schema")
+                .withSchemaType(UploadSchemaType.IOS_SURVEY).build();
         assertEquals("Zero Revision Schema", testSchema.getName());
         assertEquals(0, testSchema.getRevision().intValue());
         assertEquals("zero-revision-schema", testSchema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_SURVEY, testSchema.getSchemaType());
 
         // only check the field name, since everything else is tested by UploadFieldDefinitionTest
         List<UploadFieldDefinition> outputFieldDefList = testSchema.getFieldDefinitions();
@@ -108,10 +122,12 @@ public class UploadSchemaTest {
     @Test
     public void positiveRevision() {
         UploadSchema testSchema = new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList())
-                .withName("Positive Revision Schema").withRevision(1).withSchemaId("positive-revision-schema").build();
+                .withName("Positive Revision Schema").withRevision(1).withSchemaId("positive-revision-schema")
+                .withSchemaType(UploadSchemaType.IOS_SURVEY).build();
         assertEquals("Positive Revision Schema", testSchema.getName());
         assertEquals(1, testSchema.getRevision().intValue());
         assertEquals("positive-revision-schema", testSchema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_SURVEY, testSchema.getSchemaType());
 
         // only check the field name, since everything else is tested by UploadFieldDefinitionTest
         List<UploadFieldDefinition> outputFieldDefList = testSchema.getFieldDefinitions();
@@ -125,10 +141,12 @@ public class UploadSchemaTest {
                 new UploadFieldDefinition("foo", UploadFieldType.STRING),
                 new UploadFieldDefinition("bar", UploadFieldType.BOOLEAN),
                 new UploadFieldDefinition("baz", UploadFieldType.INT))
-                .withName("Field Def Varargs Schema").withSchemaId("field-def-varargs-schema").build();
+                .withName("Field Def Varargs Schema").withSchemaId("field-def-varargs-schema")
+                .withSchemaType(UploadSchemaType.IOS_SURVEY).build();
         assertEquals("Field Def Varargs Schema", testSchema.getName());
         assertNull(testSchema.getRevision());
         assertEquals("field-def-varargs-schema", testSchema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_SURVEY, testSchema.getSchemaType());
 
         // only check the field name, since everything else is tested by UploadFieldDefinitionTest
         List<UploadFieldDefinition> outputFieldDefList = testSchema.getFieldDefinitions();
@@ -141,7 +159,8 @@ public class UploadSchemaTest {
     @Test
     public void builderCopyOf() {
         UploadSchema originalSchema = new UploadSchema.Builder().withFieldDefinitions(mutableFieldDefList())
-                .withName("Copied Schema").withRevision(1).withSchemaId("copied-schema").build();
+                .withName("Copied Schema").withRevision(1).withSchemaId("copied-schema")
+                .withSchemaType(UploadSchemaType.IOS_SURVEY).build();
         UploadSchema copiedSchema = new UploadSchema.Builder().copyOf(originalSchema).build();
         assertEquals(originalSchema, copiedSchema);
     }
@@ -153,6 +172,7 @@ public class UploadSchemaTest {
                 "   \"name\":\"Test Schema\",\n" +
                 "   \"revision\":3,\n" +
                 "   \"schemaId\":\"test-schema\",\n" +
+                "   \"schemaType\":\"ios_data\",\n" +
                 "   \"fieldDefinitions\":[\n" +
                 "       {\n" +
                 "           \"name\":\"foo\",\n" +
@@ -166,6 +186,7 @@ public class UploadSchemaTest {
         assertEquals("Test Schema", uploadSchema.getName());
         assertEquals(3, uploadSchema.getRevision().intValue());
         assertEquals("test-schema", uploadSchema.getSchemaId());
+        assertEquals(UploadSchemaType.IOS_DATA, uploadSchema.getSchemaType());
 
         // only check the field name, since everything else is tested by UploadFieldDefinitionTest
         List<UploadFieldDefinition> fieldDefList = uploadSchema.getFieldDefinitions();
@@ -177,10 +198,11 @@ public class UploadSchemaTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = Utilities.getMapper().readValue(convertedJson, Utilities.TYPE_REF_RAW_MAP);
-        assertEquals(4, jsonMap.size());
+        assertEquals(5, jsonMap.size());
         assertEquals("Test Schema", jsonMap.get("name"));
         assertEquals(3, jsonMap.get("revision"));
         assertEquals("test-schema", jsonMap.get("schemaId"));
+        assertEquals("ios_data", jsonMap.get("schemaType"));
 
         // only check the field name, since everything else is tested by UploadFieldDefinitionTest
         List<Map<String, Object>> fieldDefJsonList = (List<Map<String, Object>>) jsonMap.get("fieldDefinitions");


### PR DESCRIPTION
Changes:
- add schema type to Upload Schema - This allows us to have separate logic in the iOS Upload Validation handlers to distinguish between surveys and non-surveys.
- add survey schema to Upload integration test bootstrapping - Currently, this schema already exists everywhere, but adding it to the bootstrap so that a new stack or a new local box will work out of the box.

Testing done:
- ran integration tests against devo, staging, and prod
- deleted the upload integration test schemas on my local box and validated that the integration test recreted them
