### PR TITLE
Adding a delete permanently method to admin client, adjusting tests

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/AdminClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/AdminClient.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.sdk;
 
-import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.VersionHolder;
@@ -37,9 +36,12 @@ public interface AdminClient {
 
     public void deleteStudy(String identifier);
 
-    public void deleteSurvey(String guid, DateTime createdOn);
-
-    public void deleteSurvey(GuidCreatedOnVersionHolder keys);
+    /**
+     * Delete a survey permanently. This delete will occur whether or not the survey version is in use 
+     * or not; developers should use the deleteSurvey() method on the DeveloperClient.
+     * @param keys
+     */
+    public void deleteSurveyPermanently(GuidCreatedOnVersionHolder keys);
     
     public ResourceList<String> getCacheItemKeys();
     

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeAdminClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeAdminClient.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.http.HttpResponse;
-import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.SimpleVersionHolder;
@@ -78,15 +77,9 @@ final class BridgeAdminClient extends BaseApiCaller implements AdminClient {
     }
 
     @Override
-    public void deleteSurvey(String guid, DateTime createdOn) {
+    public void deleteSurveyPermanently(GuidCreatedOnVersionHolder keys) {
         session.checkSignedIn();
-        delete(config.getSurveyApi(guid, createdOn));
-    }
-
-    @Override
-    public void deleteSurvey(GuidCreatedOnVersionHolder keys) {
-        session.checkSignedIn();
-        delete(config.getSurveyApi(keys.getGuid(), keys.getCreatedOn()));
+        delete(config.getDeleteSurveyPermanentlyApi(keys.getGuid(), keys.getCreatedOn()));
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -65,6 +65,7 @@ public final class Config {
         SURVEYS_PUBLISHED_API,
         SURVEYS_RECENT_API,
         SURVEY_API,
+        SURVEY_DELETE_PERMANENTLY_API,
         SURVEY_IDENTIFIER_API,
         SURVEY_PUBLISHED_REVISION_API,
         SURVEY_PUBLISH_API,
@@ -265,6 +266,11 @@ public final class Config {
         checkArgument(isNotBlank(guid));
         checkNotNull(createdOn);
         return String.format(val(Props.SURVEY_API), guid, createdOn.toString(ISODateTimeFormat.dateTime()));
+    }
+    public String getDeleteSurveyPermanentlyApi(String guid, DateTime createdOn) {
+        checkArgument(isNotBlank(guid));
+        checkNotNull(createdOn);
+        return String.format(val(Props.SURVEY_DELETE_PERMANENTLY_API), guid, createdOn.toString(ISODateTimeFormat.dateTime()));
     }
     public String getSurveyApi(String guid, String createdOn) {
         checkArgument(isNotBlank(guid));

--- a/src/main/resources/bridge-sdk.properties
+++ b/src/main/resources/bridge-sdk.properties
@@ -23,6 +23,7 @@ surveys.api = /v3/surveys
 surveys.recent.api = /v3/surveys/recent
 surveys.published.api = /v3/surveys/published
 survey.api = /v3/surveys/%s/revisions/%s
+survey.delete.permanently.api = /v3/surveys/%s/revisions/%s?physical=true
 survey.identifier.api = /v3/surveys/%s
 survey.revisions.api = /v3/surveys/%s/revisions
 survey.recent.revision.api = /v3/surveys/%s/revisions/recent

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -6,7 +6,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.IntegrationSmokeTest;
@@ -22,7 +21,6 @@ import org.sagebionetworks.bridge.sdk.exceptions.BridgeServerException;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
 import org.sagebionetworks.bridge.sdk.models.users.EmailCredentials;
 import org.sagebionetworks.bridge.sdk.models.users.SignInCredentials;
-import org.sagebionetworks.bridge.sdk.models.users.SignUpByAdmin;
 import org.sagebionetworks.bridge.sdk.models.users.SignUpCredentials;
 
 @Category(IntegrationSmokeTest.class)


### PR DESCRIPTION
deleteSurvey() was duplicated in the developer and admin clients; removed it from the admin client and added deleteSurveyPermanently().

Ran all tests and verified that no surveys/survey elements were left in DDB.
