### PR TITLE
Adding some logging around possible failure in dev

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -80,6 +80,8 @@ public class AuthenticationTest {
             } catch(BridgeServerException e) {
                 assertEquals(404, e.getStatusCode());
             }
+        } catch(Exception e) {
+            fail("Threw an exception creating a study: " + e.getMessage());
         } finally {
             config.set(Props.STUDY_IDENTIFIER, "api");
             client.deleteStudy("secondstudy");


### PR DESCRIPTION
It looks like the failure isn't logged, then it tries to delete a study that doesn't exist, and we see that failure.
