### PR TITLE
Test Tweaks: make email templates smaller; don't delete studies if creating study fails

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/Tests.java
+++ b/src/test/java/org/sagebionetworks/bridge/Tests.java
@@ -18,11 +18,16 @@ import org.sagebionetworks.bridge.sdk.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.sdk.models.schedules.SimpleScheduleStrategy;
 import org.sagebionetworks.bridge.sdk.models.schedules.SurveyReference;
 import org.sagebionetworks.bridge.sdk.models.schedules.TaskReference;
+import org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate;
 
 public class Tests {
     
     public static final String TEST_KEY = "api";
-    
+    public static final EmailTemplate TEST_RESET_PASSWORD_TEMPLATE = new EmailTemplate("Reset your password",
+            "<p>${url}</p>", EmailTemplate.MimeType.HTML);
+    public static final EmailTemplate TEST_VERIFY_EMAIL_TEMPLATE = new EmailTemplate("Verify your email",
+            "<p>${url}</p>", EmailTemplate.MimeType.HTML);
+
     public static final Properties getApplicationProperties() {
         Properties properties = new Properties();
         File file = new File("src/main/resources/bridge-sdk.properties");

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -89,8 +89,6 @@ public class AuthenticationTest {
             } catch(BridgeServerException e) {
                 assertEquals(404, e.getStatusCode());
             }
-        } catch(Exception e) {
-            fail("Threw an exception creating a study: " + e.getMessage());
         } finally {
             config.set(Props.STUDY_IDENTIFIER, "api");
             client.deleteStudy(studyId);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/AuthenticationTest.java
@@ -68,17 +68,19 @@ public class AuthenticationTest {
         AdminClient client = ClientProvider.signIn(config.getAdminCredentials()).getAdminClient();
         String studyId = Tests.randomIdentifier(AuthenticationTest.class);
 
+        // Make a second study for this test:
+        Study study = new Study();
+        study.setIdentifier(studyId);
+        study.setName("Second Study");
+        study.setSponsorName("Second Study");
+        study.setSupportEmail("bridge-testing+support@sagebase.org");
+        study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
+        study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
+        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
+        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
+        client.createStudy(study);
+
         try {
-            // Make a second study for this test:
-            Study study = new Study();
-            study.setIdentifier(studyId);
-            study.setName("Second Study");
-            study.setSponsorName("Second Study");
-            study.setSupportEmail("bridge-testing+support@sagebase.org");
-            study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
-            study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
-            client.createStudy(study);
-            
             // Can we sign in to secondstudy? No.
             try {
                 config.set(Props.STUDY_IDENTIFIER, studyId);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.sdk.integration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,8 +43,6 @@ public class UTF8Test {
             Study returnedStudy = adminClient.getStudy(studyId);
             assertEquals(studyId, returnedStudy.getIdentifier());
             assertEquals(studyName, returnedStudy.getName());
-        } catch(Throwable t) {
-            fail(t.getMessage());
         } finally {
             // clean-up: delete study
             adminClient.deleteStudy(studyId);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UTF8Test.java
@@ -25,19 +25,21 @@ public class UTF8Test {
         String studyName = "☃지구상의　３대　극지라　불리는";
         AdminClient adminClient = TestUserHelper.getSignedInAdmin().getSession().getAdminClient();
 
+        // make minimal study
+        Study study = new Study();
+        study.setIdentifier(studyId);
+        study.setName(studyName);
+        study.setSponsorName(studyName);
+        study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
+        study.setSupportEmail("bridge-testing+support@sagebase.org");
+        study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
+        study.setResetPasswordTemplate(Tests.TEST_RESET_PASSWORD_TEMPLATE);
+        study.setVerifyEmailTemplate(Tests.TEST_VERIFY_EMAIL_TEMPLATE);
+
+        // create study
+        adminClient.createStudy(study);
+
         try {
-            // make minimal study
-            Study study = new Study();
-            study.setIdentifier(studyId);
-            study.setName(studyName);
-            study.setSponsorName(studyName);
-            study.setTechnicalEmail("bridge-testing+technical@sagebase.org");
-            study.setSupportEmail("bridge-testing+support@sagebase.org");
-            study.setConsentNotificationEmail("bridge-testing+consent@sagebase.org");
-
-            // create study
-            adminClient.createStudy(study);
-
             // get study back and verify fields
             Study returnedStudy = adminClient.getStudy(studyId);
             assertEquals(studyId, returnedStudy.getIdentifier());


### PR DESCRIPTION
Two tweaks:
1. We're getting DDB throttling on the Study table for burst traffic during integration tests. It looks like this is happening because email templates are fairly large, so we brown out the Study table quickly. This change makes the email templates much smaller, in attempts to mitigate that.
2. If createStudy() fails, the tests will attempt to delete the study anyway. The delete fails with a "study not found". (Because deleteStudy() checks Redis for the study to determine if the study exists, and this happens on the last step of createStudy(). So in general, if createStudy() fails, deleteStudy() will almost always fail.) This change moves createStudy() outside of the try-finally, so we won't try to delete a non-existent study.

Testing done: Ran integration tests against devo, staging, and prod.
