### PR TITLE
updated SurveyTest and SurveyResponseTest to clean up after themselves instead of nuking all surveys from orbit

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidCreatedOnVersionHolder.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidCreatedOnVersionHolder.java
@@ -28,6 +28,14 @@ public final class SimpleGuidCreatedOnVersionHolder implements GuidCreatedOnVers
         this.createdOn = createdOn;
         this.version = version;
     }
+
+    /**
+     * Copy constructor. This is used to get an immutable simple version holder from a survey or an unknown concrete
+     * version holder type.
+     */
+    public SimpleGuidCreatedOnVersionHolder(GuidCreatedOnVersionHolder other) {
+        this(other.getGuid(), other.getCreatedOn(), other.getVersion());
+    }
     
     public String getGuid() {
         return guid;
@@ -64,9 +72,7 @@ public final class SimpleGuidCreatedOnVersionHolder implements GuidCreatedOnVers
 
     @Override
     public String toString() {
-        return String.format("SimpleGuidCreatedOnVersionHolder [guid=%s, createdOn=$s, version=%s]", 
+        return String.format("SimpleGuidCreatedOnVersionHolder [guid=%s, createdOn=%s, version=%s]",
                 guid, createdOn, version);
     }
-
-
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyResponseTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyResponseTest.java
@@ -15,8 +15,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.IntegrationSmokeTest;
+import org.sagebionetworks.bridge.sdk.AdminClient;
 import org.sagebionetworks.bridge.sdk.DeveloperClient;
 import org.sagebionetworks.bridge.sdk.Roles;
+import org.sagebionetworks.bridge.sdk.Session;
 import org.sagebionetworks.bridge.sdk.TestSurvey;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
@@ -58,14 +60,27 @@ public class SurveyResponseTest {
     }
 
     @AfterClass
-    public static void afterClass() {
-        try {
-            user.signOutAndDeleteUser();
-        } finally {
+    public static void deleteDeveloper() {
+        if (developer != null) {
             developer.signOutAndDeleteUser();
         }
     }
-    
+
+    @AfterClass
+    public static void deleteUser() {
+        if (user != null) {
+            user.signOutAndDeleteUser();
+        }
+    }
+
+    @AfterClass
+    public static void deleteSurvey() {
+        // cleanup test survey
+        Session session = TestUserHelper.getSignedInAdmin().getSession();
+        AdminClient adminClient = session.getAdminClient();
+        adminClient.deleteSurveyPermanently(keys);
+    }
+
     /**
      * You don't need answers to create a survey response. You get the identifier for future answers
      * to submit. 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidCreatedOnVersionHolderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidCreatedOnVersionHolderTest.java
@@ -1,15 +1,38 @@
 package org.sagebionetworks.bridge.sdk.models.holders;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 public class SimpleGuidCreatedOnVersionHolderTest {
-    
+    @Test
+    public void copyConstructor() {
+        SimpleGuidCreatedOnVersionHolder original = new SimpleGuidCreatedOnVersionHolder("test-guid",
+                DateTime.parse("2015-09-25T17:02-0700"), 42L);
+        SimpleGuidCreatedOnVersionHolder copy = new SimpleGuidCreatedOnVersionHolder(original);
+        assertEquals(original, copy);
+    }
+
     @Test
     public void equalsContract() {
         EqualsVerifier.forClass(SimpleGuidCreatedOnVersionHolder.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
     }
 
+    @Test
+    public void testToString() {
+        DateTime createdOn = DateTime.parse("2015-09-25T17:02-0700");
+        SimpleGuidCreatedOnVersionHolder versionHolder = new SimpleGuidCreatedOnVersionHolder("test-guid", createdOn,
+                42L);
+        String versionHolderStr = versionHolder.toString();
+
+        // Instead of exact string-matching (which is finnicky), just test that the string includes our expected parts
+        assertTrue(versionHolderStr.contains("test-guid"));
+        assertTrue(versionHolderStr.contains(createdOn.toString()));
+        assertTrue(versionHolderStr.contains("42"));
+    }
 }


### PR DESCRIPTION
Two changes:
#1, updated the cleanup code in SurveyTest and SurveyResponseTest to track the surveys they create and delete only those surveys.
#2, updated the "containsAll()" check in SurveyTest to not break when there are extra surveys in the study.

These changes mean
(a) these tests are less finnicky when there are other surveys leftover in the survey
(b) if tests run concurrently (which can happen if two developers run integration tests against the same environment, or if someone runs unit tests and integration tests concurrently, or a build runs concurrently with integration tests), they won't interfere with each other
(c) we can have persistent test surveys in the api study.

Testing done:
- ran SurveyTest and SurveyResponseTest against dev and uat
- ran SimpleGuidCreatedOnVersionHolderTest

See also https://sagebionetworks.jira.com/browse/BRIDGE-805
