### PR TITLE
remove sendStudyParticipantsRoster test

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyTest.java
@@ -156,22 +156,7 @@ public class StudyTest {
             developer.signOutAndDeleteUser();
         }
     }
-    
-    @Test
-    public void researcherCanRetrieveConsentedParticipants() {
-        TestUser researcher = TestUserHelper.createAndSignInUser(StudyTest.class, false, Roles.RESEARCHER);
-        TestUser user = TestUserHelper.createAndSignInUser(StudyTest.class, true);
-        try {
-            ResearcherClient client = researcher.getSession().getResearcherClient();
-            client.sendStudyParticipantsRoster();
-        } catch(Exception e) {
-            fail("Threw exception");
-        } finally {
-            user.signOutAndDeleteUser();
-            researcher.signOutAndDeleteUser();
-        }
-    }
-    
+
     @Test(expected = UnauthorizedException.class)
     public void adminCannotRetrieveParticipants() {
         ResearcherClient client = admin.getSession().getResearcherClient();


### PR DESCRIPTION
Since sendStudyParticipantsRoster is an asynchronous call that sends its results over email, this test doesn't actually test anything. The async job also has the potential to consume a lot of DDB Read Capacity. We should remove it.
