### PR TITLE
Do not update API study

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduleTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.sdk.integration;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
@@ -18,13 +17,9 @@ import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.UserClient;
 import org.sagebionetworks.bridge.sdk.models.schedules.Schedule;
 import org.sagebionetworks.bridge.sdk.models.schedules.SchedulePlan;
-import org.sagebionetworks.bridge.sdk.models.studies.Study;
-
-import com.google.common.collect.Sets;
 
 public class ScheduleTest {
 
-    private static final Set<String> TASK_IDENTIFIERS = Sets.newHashSet("task:AAA", "task:BBB", "task:CCC", "CCC");
     private String planGuid;
     
     private TestUser user;
@@ -34,14 +29,6 @@ public class ScheduleTest {
     public void before() {
         user = TestUserHelper.createAndSignInUser(ScheduleTest.class, true);
         developer = TestUserHelper.createAndSignInUser(ScheduleTest.class, true, Roles.DEVELOPER);
-        
-        DeveloperClient developerClient = developer.getSession().getDeveloperClient();
-        Study study = developerClient.getStudy();
-        Set<String> taskIdentifiers = study.getTaskIdentifiers();
-        if (!taskIdentifiers.containsAll(TASK_IDENTIFIERS)) {
-            taskIdentifiers.addAll(TASK_IDENTIFIERS);
-            developerClient.updateStudy(study);
-        }
         ClientProvider.setClientInfo(new ClientInfo.Builder().withAppName(Tests.APP_NAME).withAppVersion(3).build());
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/ScheduledActivityTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.util.Set;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -29,7 +27,6 @@ import org.sagebionetworks.bridge.sdk.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.sdk.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.sdk.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.sdk.models.schedules.TaskReference;
-import org.sagebionetworks.bridge.sdk.models.studies.Study;
 import org.sagebionetworks.bridge.sdk.models.schedules.ScheduledActivityStatus;
 
 @Category(IntegrationSmokeTest.class)
@@ -46,13 +43,6 @@ public class ScheduledActivityTest {
         user = TestUserHelper.createAndSignInUser(SchedulePlanTest.class, true);
 
         developerClient = developer.getSession().getDeveloperClient();
-        Study study = developerClient.getStudy();
-        Set<String> taskIdentifiers = study.getTaskIdentifiers();
-        if (!taskIdentifiers.contains("task1")) {
-            study.getTaskIdentifiers().add("task1");
-            developerClient.updateStudy(study);
-        }
-        
         userClient = user.getSession().getUserClient();
         
         Schedule schedule = new Schedule();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
@@ -2,8 +2,6 @@ package org.sagebionetworks.bridge.sdk.integration;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,13 +9,11 @@ import org.junit.experimental.categories.Category;
 
 import org.sagebionetworks.bridge.IntegrationSmokeTest;
 import org.sagebionetworks.bridge.sdk.ClientProvider;
-import org.sagebionetworks.bridge.sdk.DeveloperClient;
 import org.sagebionetworks.bridge.sdk.Roles;
 import org.sagebionetworks.bridge.sdk.Session;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.UserClient;
-import org.sagebionetworks.bridge.sdk.models.studies.Study;
 import org.sagebionetworks.bridge.sdk.models.users.DataGroups;
 
 import com.google.common.collect.Sets;
@@ -32,14 +28,6 @@ public class SignInTest {
     public void before() {
         developer = TestUserHelper.createAndSignInUser(SignInTest.class, true, Roles.DEVELOPER);
         user = TestUserHelper.createAndSignInUser(SignInTest.class, true);
-        
-        DeveloperClient devClient = developer.getSession().getDeveloperClient();
-        Study study = devClient.getStudy();
-        Set<String> dataGroups = study.getDataGroups();
-        if (!dataGroups.contains("sdk-int-1")) {
-            dataGroups.add("sdk-int-1");
-            devClient.updateStudy(study);
-        }
     }
     
     @After

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserProfileTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/UserProfileTest.java
@@ -2,19 +2,15 @@ package org.sagebionetworks.bridge.sdk.integration;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sagebionetworks.bridge.IntegrationSmokeTest;
-import org.sagebionetworks.bridge.sdk.DeveloperClient;
 import org.sagebionetworks.bridge.sdk.Roles;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.UserClient;
-import org.sagebionetworks.bridge.sdk.models.studies.Study;
 import org.sagebionetworks.bridge.sdk.models.users.DataGroups;
 import org.sagebionetworks.bridge.sdk.models.users.ExternalIdentifier;
 import org.sagebionetworks.bridge.sdk.models.users.UserProfile;
@@ -24,20 +20,11 @@ import com.google.common.collect.Sets;
 @Category(IntegrationSmokeTest.class)
 public class UserProfileTest {
 
-    private static final Set<String> DATA_GROUPS = Sets.newHashSet("sdk-int-1","sdk-int-2");
     private TestUser developer;
 
     @Before
     public void before() {
         developer = TestUserHelper.createAndSignInUser(UserProfileTest.class, true, Roles.DEVELOPER);
-        
-        DeveloperClient devClient = developer.getSession().getDeveloperClient();
-        Study study = devClient.getStudy();
-        Set<String> dataGroups = study.getDataGroups();
-        if (!dataGroups.containsAll(DATA_GROUPS)) {
-            dataGroups.addAll(DATA_GROUPS);
-            devClient.updateStudy(study);
-        }
     }
 
     @After


### PR DESCRIPTION
There's a small chance that multiple tests could encounter a concurrent modification exception if they're both modifying the api study. Instead, as all the studies in all environments are currently correct, create the necessary task identifiers and data groups in the BridgePF default study bootstrapper.

There are currently enough of both of these for the integration tests (Java and iOS) so we should reuse these instead of adding more of them.
