### PR TITLE
updated TestUserHelper to clean up on failure

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SignInTest.java
@@ -44,8 +44,12 @@ public class SignInTest {
     
     @After
     public void after() {
-        user.signOutAndDeleteUser();
-        developer.signOutAndDeleteUser();
+        if (user != null) {
+            user.signOutAndDeleteUser();
+        }
+        if (developer != null) {
+            developer.signOutAndDeleteUser();
+        }
     }
 
     @Test


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-1080

Since the Admin createUser API already has a flag for consent, I deleted the code path where we consent and just had it propagate the error instead.

Also added try-catch around the signIn, in case it fails, to clean up accounts (since callers won't be able to).

Also fixed SignInTest to properly clean up both accounts.

Testing done:
- Used SignInTest for testing
- Added a required subpop to my local API study. Verified that tests broke and left accounts behind.
- Fixed TestUserHelper. Verified that tests still broke, but properly cleaned up accounts.
- Set subpop to optional. Verified tests now pass.
