### PR TITLE
Fix test that was leaving a survey behind after each run

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/sdk/TestSurvey.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/TestSurvey.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+
+import org.sagebionetworks.bridge.Tests;
 import org.sagebionetworks.bridge.sdk.models.surveys.BooleanConstraints;
 import org.sagebionetworks.bridge.sdk.models.surveys.DataType;
 import org.sagebionetworks.bridge.sdk.models.surveys.DateConstraints;
@@ -38,7 +40,7 @@ public class TestSurvey {
     public static final String INTEGER_ID = "BP X DAY";
     public static final String TIME_ID = "deleuterium_x_day";
     
-    public static final Survey getSurvey() {
+    public static final Survey getSurvey(Class<?> cls) {
         Survey survey = new Survey();
         
         SurveyQuestion multiValueQuestion = new SurveyQuestion();
@@ -139,7 +141,7 @@ public class TestSurvey {
         timeQuestion.setUiHint(UiHint.TIMEPICKER);
         
         survey.setName("General Blood Pressure Survey");
-        survey.setIdentifier("bloodpressure");
+        survey.setIdentifier(Tests.randomIdentifier(cls));
         List<SurveyElement> elements = survey.getElements();
         elements.add(booleanQuestion);
         elements.add(dateQuestion);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
@@ -46,6 +46,7 @@ public class SchedulePlanTest {
 
     private static final ObjectMapper MAPPER = Utilities.getMapper();
 
+    private TestUser admin;
     private TestUser user;
     private TestUser developer;
     private DeveloperClient developerClient;
@@ -53,6 +54,7 @@ public class SchedulePlanTest {
 
     @Before
     public void before() {
+        admin = TestUserHelper.getSignedInAdmin();
         developer = TestUserHelper.createAndSignInUser(SchedulePlanTest.class, true, Roles.DEVELOPER);
         user = TestUserHelper.createAndSignInUser(SchedulePlanTest.class, true);
 
@@ -210,7 +212,7 @@ public class SchedulePlanTest {
         GuidCreatedOnVersionHolder surveyKeys = null;
         GuidVersionHolder keys = null;
         try {
-            Survey survey = TestSurvey.getSurvey();
+            Survey survey = TestSurvey.getSurvey(SchedulePlanTest.class);
             surveyKeys = developerClient.createSurvey(survey);
 
             // Can we point to the most recently published survey, rather than a specific version?
@@ -233,9 +235,11 @@ public class SchedulePlanTest {
             Tests.getActivitiesFromSimpleStrategy(plan).set(0, Tests.getActivityFromSimpleStrategy(newPlan));
 
             assertEquals(plan, newPlan);
+        } catch(Exception e) {
+            e.printStackTrace();
         } finally {
             developerClient.deleteSchedulePlan(keys.getGuid());
-            developerClient.deleteSurvey(surveyKeys);
+            admin.getSession().getAdminClient().deleteSurveyPermanently(surveyKeys);
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SchedulePlanTest.java
@@ -235,8 +235,6 @@ public class SchedulePlanTest {
             Tests.getActivitiesFromSimpleStrategy(plan).set(0, Tests.getActivityFromSimpleStrategy(newPlan));
 
             assertEquals(plan, newPlan);
-        } catch(Exception e) {
-            e.printStackTrace();
         } finally {
             developerClient.deleteSchedulePlan(keys.getGuid());
             admin.getSession().getAdminClient().deleteSurveyPermanently(surveyKeys);

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyResponseTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyResponseTest.java
@@ -50,7 +50,7 @@ public class SurveyResponseTest {
         user = TestUserHelper.createAndSignInUser(SurveyResponseTest.class, true);
 
         DeveloperClient client = developer.getSession().getDeveloperClient();
-        Survey testSurvey = TestSurvey.getSurvey();
+        Survey testSurvey = TestSurvey.getSurvey(SurveyResponseTest.class);
         keys = client.createSurvey(testSurvey);
         client.publishSurvey(keys);
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/SurveyTest.java
@@ -115,7 +115,7 @@ public class SurveyTest {
     @Test
     public void saveAndRetrieveSurvey() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
-        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         Survey survey = client.getSurvey(key);
 
         List<SurveyElement> questions = survey.getElements();
@@ -135,7 +135,7 @@ public class SurveyTest {
     public void createVersionPublish() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
 
-        Survey survey = TestSurvey.getSurvey();
+        Survey survey = TestSurvey.getSurvey(SurveyTest.class);
         assertNull(survey.getGuid());
         assertNull(survey.getVersion());
         assertNull(survey.getCreatedOn());
@@ -159,7 +159,7 @@ public class SurveyTest {
     public void getAllVersionsOfASurvey() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
 
-        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         key = versionSurvey(client, key);
 
         int count = client.getSurveyAllRevisions(key.getGuid()).getTotal();
@@ -170,15 +170,15 @@ public class SurveyTest {
     public void canGetMostRecentOrRecentlyPublishedSurvey() throws InterruptedException {
         DeveloperClient client = developer.getSession().getDeveloperClient();
 
-        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         key = versionSurvey(client, key);
         key = versionSurvey(client, key);
 
-        GuidCreatedOnVersionHolder key1 = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key1 = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         key1 = versionSurvey(client, key1);
         key1 = versionSurvey(client, key1);
 
-        GuidCreatedOnVersionHolder key2 = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key2 = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         key2 = versionSurvey(client, key2);
         key2 = versionSurvey(client, key2);
 
@@ -195,7 +195,7 @@ public class SurveyTest {
     public void canUpdateASurveyAndTypesAreCorrect() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
 
-        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         Survey survey = client.getSurvey(key.getGuid(), key.getCreatedOn());
         assertEquals("Type is Survey.", survey.getClass(), Survey.class);
 
@@ -228,7 +228,7 @@ public class SurveyTest {
     public void dateBasedConstraintsPersistedCorrectly() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
 
-        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey());
+        GuidCreatedOnVersionHolder key = createSurvey(client, TestSurvey.getSurvey(SurveyTest.class));
         Survey survey = client.getSurvey(key);
 
         DateTimeConstraints dateCon = (DateTimeConstraints)getConstraints(survey, DATETIME_ID);
@@ -243,7 +243,7 @@ public class SurveyTest {
     @Test
     public void researcherCannotUpdatePublishedSurvey() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
-        Survey survey = TestSurvey.getSurvey();
+        Survey survey = TestSurvey.getSurvey(SurveyTest.class);
         GuidCreatedOnVersionHolder keys = createSurvey(client, survey);
         keys = client.publishSurvey(keys);
         survey.setGuidCreatedOnVersionHolder(keys);
@@ -260,7 +260,7 @@ public class SurveyTest {
     @Test
     public void canGetMostRecentlyPublishedSurveyWithoutTimestamp() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
-        Survey survey = TestSurvey.getSurvey();
+        Survey survey = TestSurvey.getSurvey(SurveyTest.class);
 
         GuidCreatedOnVersionHolder key = createSurvey(client, survey);
 
@@ -277,7 +277,7 @@ public class SurveyTest {
     @Test
     public void canCallMultiOperationMethodToMakeSurveyUpdate() {
         DeveloperClient client = developer.getSession().getDeveloperClient();
-        Survey survey = TestSurvey.getSurvey();
+        Survey survey = TestSurvey.getSurvey(SurveyTest.class);
 
         GuidCreatedOnVersionHolder keys = createSurvey(client, survey);
 


### PR DESCRIPTION
Most probably the source of all the leftover bloodpressure surveys on UAT, though I will review BridgePF as well.
