### PR TITLE
Study consent permission and test changes

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
@@ -55,7 +55,7 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
         checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
         
         return get(config.getMostRecentStudyConsentApi(subpopGuid), StudyConsent.class);
-    };
+    }
     @Override
     public StudyConsent getStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn) {
         session.checkSignedIn();

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.sdk.models.holders.SimpleVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.VersionHolder;
 import org.sagebionetworks.bridge.sdk.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
+import org.sagebionetworks.bridge.sdk.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
     
+    private final TypeReference<ResourceListImpl<StudyConsent>> scType = new TypeReference<ResourceListImpl<StudyConsent>>() {};
     private final TypeReference<ResourceListImpl<Survey>> sType = new TypeReference<ResourceListImpl<Survey>>() {};
     private final TypeReference<ResourceListImpl<SchedulePlan>> spType = new TypeReference<ResourceListImpl<SchedulePlan>>() {};
     private final TypeReference<ResourceListImpl<Subpopulation>> subpopType = new TypeReference<ResourceListImpl<Subpopulation>>() {};
@@ -33,6 +35,51 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
         super(session);
     }
 
+    @Override
+    public ResourceList<StudyConsent> getAllStudyConsents(SubpopulationGuid subpopGuid) {
+        session.checkSignedIn();
+        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
+
+        return get(config.getConsentsApi(subpopGuid), scType);
+    }
+    @Override
+    public StudyConsent getPublishedStudyConsent(SubpopulationGuid subpopGuid) {
+        session.checkSignedIn();
+        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
+        
+        return get(config.getPublishedStudyConsentApi(subpopGuid), StudyConsent.class);
+    }
+    @Override
+    public StudyConsent getMostRecentStudyConsent(SubpopulationGuid subpopGuid) {
+        session.checkSignedIn();
+        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
+        
+        return get(config.getMostRecentStudyConsentApi(subpopGuid), StudyConsent.class);
+    };
+    @Override
+    public StudyConsent getStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn) {
+        session.checkSignedIn();
+        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
+        checkNotNull(createdOn, CANNOT_BE_NULL, "createdOn");
+
+        return get(config.getConsentApi(subpopGuid, createdOn), StudyConsent.class);
+    }
+    @Override
+    public void createStudyConsent(SubpopulationGuid subpopGuid, StudyConsent consent) {
+        session.checkSignedIn();
+        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
+        checkNotNull(consent, CANNOT_BE_NULL, "consent");
+
+        post(config.getConsentsApi(subpopGuid), consent, StudyConsent.class);
+    }
+    @Override
+    public void publishStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn) {
+        session.checkSignedIn();
+        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
+        checkNotNull(createdOn, CANNOT_BE_NULL, "createdOn");
+
+        post(config.getPublishStudyConsentApi(subpopGuid, createdOn));
+    }
     @Override
     public Survey getSurvey(String guid, DateTime createdOn) {
         session.checkSignedIn();

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
@@ -1,66 +1,9 @@
 package org.sagebionetworks.bridge.sdk;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import org.joda.time.DateTime;
-import org.sagebionetworks.bridge.sdk.models.ResourceList;
-import org.sagebionetworks.bridge.sdk.models.subpopulations.StudyConsent;
-import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-
 class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
-    
-    private final TypeReference<ResourceListImpl<StudyConsent>> scType = new TypeReference<ResourceListImpl<StudyConsent>>() {};
 
     BridgeResearcherClient(BridgeSession session) {
         super(session);
-    }
-
-    @Override
-    public ResourceList<StudyConsent> getAllStudyConsents(SubpopulationGuid subpopGuid) {
-        session.checkSignedIn();
-        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-
-        return get(config.getConsentsApi(subpopGuid), scType);
-    }
-    @Override
-    public StudyConsent getPublishedStudyConsent(SubpopulationGuid subpopGuid) {
-        session.checkSignedIn();
-        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-        
-        return get(config.getPublishedStudyConsentApi(subpopGuid), StudyConsent.class);
-    }
-    @Override
-    public StudyConsent getMostRecentStudyConsent(SubpopulationGuid subpopGuid) {
-        session.checkSignedIn();
-        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-        
-        return get(config.getMostRecentStudyConsentApi(subpopGuid), StudyConsent.class);
-    };
-    @Override
-    public StudyConsent getStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn) {
-        session.checkSignedIn();
-        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-        checkNotNull(createdOn, CANNOT_BE_NULL, "createdOn");
-
-        return get(config.getConsentApi(subpopGuid, createdOn), StudyConsent.class);
-    }
-    @Override
-    public void createStudyConsent(SubpopulationGuid subpopGuid, StudyConsent consent) {
-        session.checkSignedIn();
-        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-        checkNotNull(consent, CANNOT_BE_NULL, "consent");
-
-        post(config.getConsentsApi(subpopGuid), consent, StudyConsent.class);
-    }
-    @Override
-    public void publishStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn) {
-        session.checkSignedIn();
-        checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-        checkNotNull(createdOn, CANNOT_BE_NULL, "createdOn");
-
-        post(config.getPublishStudyConsentApi(subpopGuid, createdOn));
     }
     @Override
     public void sendStudyParticipantsRoster() {

--- a/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
@@ -7,12 +7,63 @@ import org.sagebionetworks.bridge.sdk.models.holders.GuidVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.VersionHolder;
 import org.sagebionetworks.bridge.sdk.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
+import org.sagebionetworks.bridge.sdk.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 public interface DeveloperClient {
+
+    // STUDY CONSENTS
+    /**
+     * Get all revisions of the consent document for the study of the current researcher.
+     * @param subpopGuid
+     * @return List<StudyConsent>
+     */
+    public ResourceList<StudyConsent> getAllStudyConsents(SubpopulationGuid subpopGuid);
+
+    /**
+     * Get the published consent document revision. This is the revision that is sent to users, and should be a
+     * version of the consent that has been approved by your IRB. Only one revision of your consent is published 
+     * at any given time.
+     * @param subpopGuid
+     * @return StudyConsent
+     */
+    public StudyConsent getPublishedStudyConsent(SubpopulationGuid subpopGuid);
+
+    /**
+     * Get the most recent revision of the consent document.
+     * @param subpopGuid
+     * @return StudyConsent
+     */
+    public StudyConsent getMostRecentStudyConsent(SubpopulationGuid subpopGuid);
+
+    /**
+     * Get a consent document that was created at a DateTime.
+     *
+     * @param subpopGuid
+     * @param createdOn
+     *            The DateTime the consent document was created on (this DateTime identifies the consent document).
+     * @return StudyConsent
+     */
+    public StudyConsent getStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn);
+
+    /**
+     * Create a consent document revision.
+     * @param subpopGuid
+     * @param consent
+     *            The consent document to add.
+     */
+    public void createStudyConsent(SubpopulationGuid subpopGuid, StudyConsent consent);
+
+    /**
+     * Publish a consent document created at a DateTime. The prior published revision will no longer be published.
+     * @param subpopGuid
+     * @param createdOn
+     *            DateTime consent document was created. This acts as an identifier for the consent document.
+     */
+    public void publishStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn);
 
     /**
      * Get the survey by its GUID for a particular DateTime revision.

--- a/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
@@ -1,61 +1,6 @@
 package org.sagebionetworks.bridge.sdk;
 
-import org.joda.time.DateTime;
-import org.sagebionetworks.bridge.sdk.models.ResourceList;
-import org.sagebionetworks.bridge.sdk.models.subpopulations.StudyConsent;
-import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
-
 public interface ResearcherClient {
-
-    // STUDY CONSENTS
-    /**
-     * Get all revisions of the consent document for the study of the current researcher.
-     * @param subpopGuid
-     * @return List<StudyConsent>
-     */
-    public ResourceList<StudyConsent> getAllStudyConsents(SubpopulationGuid subpopGuid);
-
-    /**
-     * Get the published consent document revision. This is the revision that is sent to users, and should be a
-     * version of the consent that has been approved by your IRB. Only one revision of your consent is published 
-     * at any given time.
-     * @param subpopGuid
-     * @return StudyConsent
-     */
-    public StudyConsent getPublishedStudyConsent(SubpopulationGuid subpopGuid);
-
-    /**
-     * Get the most recent revision of the consent document.
-     * @param subpopGuid
-     * @return StudyConsent
-     */
-    public StudyConsent getMostRecentStudyConsent(SubpopulationGuid subpopGuid);
-
-    /**
-     * Get a consent document that was created at a DateTime.
-     *
-     * @param subpopGuid
-     * @param createdOn
-     *            The DateTime the consent document was created on (this DateTime identifies the consent document).
-     * @return StudyConsent
-     */
-    public StudyConsent getStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn);
-
-    /**
-     * Create a consent document revision.
-     * @param subpopGuid
-     * @param consent
-     *            The consent document to add.
-     */
-    public void createStudyConsent(SubpopulationGuid subpopGuid, StudyConsent consent);
-
-    /**
-     * Publish a consent document created at a DateTime. The prior published revision will no longer be published.
-     * @param subpopGuid
-     * @param createdOn
-     *            DateTime consent document was created. This acts as an identifier for the consent document.
-     */
-    public void publishStudyConsent(SubpopulationGuid subpopGuid, DateTime createdOn);
 
     /**
      * Email a list of users who have signed consents to participate in the researcher's study. The email is sent to the

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyConsentTest.java
@@ -41,7 +41,7 @@ public class StudyConsentTest {
     }
 
     @Test(expected=BridgeSDKException.class)
-    public void mustBeDeveloperToAdd() {
+    public void cannotBeAccessedByRegularUser() {
         TestUser user = TestUserHelper.createAndSignInUser(StudyConsentTest.class, true);
         try {
             StudyConsent consent = new StudyConsent();
@@ -53,6 +53,19 @@ public class StudyConsentTest {
         }
     }
 
+    @Test(expected=BridgeSDKException.class)
+    public void cannotBeAccessedByResearcher() {
+        TestUser researcher = TestUserHelper.createAndSignInUser(StudyConsentTest.class, true, Roles.RESEARCHER);
+        try {
+            StudyConsent consent = new StudyConsent();
+            consent.setDocumentContent("<p>Test content.</p>");
+
+            researcher.getSession().getDeveloperClient().createStudyConsent(researcher.getDefaultSubpopulation(), consent);
+        } finally {
+            researcher.signOutAndDeleteUser();
+        }
+    }
+    
     @Test
     public void addAndActivateConsent() {
         DeveloperClient client = developer.getSession().getDeveloperClient();

--- a/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/integration/StudyConsentTest.java
@@ -6,80 +6,91 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.sagebionetworks.bridge.sdk.ResearcherClient;
+
+import org.sagebionetworks.bridge.Tests;
+import org.sagebionetworks.bridge.sdk.DeveloperClient;
 import org.sagebionetworks.bridge.sdk.Roles;
 import org.sagebionetworks.bridge.sdk.TestUserHelper;
 import org.sagebionetworks.bridge.sdk.TestUserHelper.TestUser;
 import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
+import org.sagebionetworks.bridge.sdk.models.holders.GuidVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.StudyConsent;
+import org.sagebionetworks.bridge.sdk.models.subpopulations.Subpopulation;
+import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 
 public class StudyConsentTest {
 
-    private TestUser researcher;
+    private TestUser admin;
+    private TestUser developer;
+    private SubpopulationGuid subpopGuid;
 
     @Before
     public void before() {
-        researcher = TestUserHelper.createAndSignInUser(StudyConsentTest.class, true, Roles.RESEARCHER);
+        admin = TestUserHelper.getSignedInAdmin();
+        developer = TestUserHelper.createAndSignInUser(StudyConsentTest.class, true, Roles.DEVELOPER);
     }
 
     @After
     public void after() {
-        researcher.signOutAndDeleteUser();
+        if (subpopGuid != null) {
+            admin.getSession().getAdminClient().deleteSubpopulationPermanently(subpopGuid);    
+        }
+        developer.signOutAndDeleteUser();
     }
 
     @Test(expected=BridgeSDKException.class)
-    public void mustBeResearcherToAdd() {
+    public void mustBeDeveloperToAdd() {
         TestUser user = TestUserHelper.createAndSignInUser(StudyConsentTest.class, true);
         try {
             StudyConsent consent = new StudyConsent();
             consent.setDocumentContent("<p>Test content.</p>");
 
-            user.getSession().getResearcherClient().createStudyConsent(user.getDefaultSubpopulation(), consent);
-
+            user.getSession().getDeveloperClient().createStudyConsent(user.getDefaultSubpopulation(), consent);
         } finally {
             user.signOutAndDeleteUser();
         }
     }
 
-    // We need to delete these consent versions; there's no clean-up for this test right now.
     @Test
-    @Ignore
     public void addAndActivateConsent() {
-        ResearcherClient client = researcher.getSession().getResearcherClient();
+        DeveloperClient client = developer.getSession().getDeveloperClient();
 
+        // Create a subpopulation to test this so we can delete the subpopulation to clean up.
+        // Because we create it from scratch, we know the exact number of consents that are in it.
+        // It is not required, so shouldn't prevent other tests from creating users.
+        Subpopulation subpop = new Subpopulation();
+        subpop.setName(Tests.randomIdentifier(StudyConsentTest.class));
+        subpop.setRequired(false);
+        GuidVersionHolder holder = client.createSubpopulation(subpop);
+        subpop.setHolder(holder);
+        subpopGuid = new SubpopulationGuid(holder.getGuid());
+        
         StudyConsent consent = new StudyConsent();
         consent.setDocumentContent("<p>Test content</p>");
-        client.createStudyConsent(researcher.getDefaultSubpopulation(), consent);
+        client.createStudyConsent(subpopGuid, consent);
 
-        ResourceList<StudyConsent> studyConsents = client.getAllStudyConsents(researcher.getDefaultSubpopulation());
+        ResourceList<StudyConsent> studyConsents = client.getAllStudyConsents(subpopGuid);
 
-        assertNotNull("studyConsents should not be null.", studyConsents);
-        assertTrue("studyConsents should have at least one StudyConsent", studyConsents.getTotal() > 0);
-        // And btw these should match
-        assertEquals("items.size() == total", studyConsents.getTotal(), studyConsents.getItems().size());
+        assertEquals(2, studyConsents.getTotal());
 
-        StudyConsent current = client.getStudyConsent(researcher.getDefaultSubpopulation(),
-                studyConsents.getItems().get(0).getCreatedOn());
-        assertNotNull("studyConsent should not be null.", current);
-        
+        StudyConsent current = client.getStudyConsent(subpopGuid, studyConsents.getItems().get(0).getCreatedOn());
         assertEquals(consent.getDocumentContent(), current.getDocumentContent());
         assertNotNull(current.getCreatedOn());
 
-        client.publishStudyConsent(researcher.getDefaultSubpopulation(), current.getCreatedOn());
+        client.publishStudyConsent(subpopGuid, current.getCreatedOn());
 
-        StudyConsent published = client.getPublishedStudyConsent(researcher.getDefaultSubpopulation());
+        StudyConsent published = client.getPublishedStudyConsent(subpopGuid);
         assertTrue("Published consent is returned.", published.isActive());
         
-        client.createStudyConsent(researcher.getDefaultSubpopulation(), current);
+        client.createStudyConsent(subpopGuid, current);
         
-        StudyConsent newOne = client.getMostRecentStudyConsent(researcher.getDefaultSubpopulation());
+        StudyConsent newOne = client.getMostRecentStudyConsent(subpopGuid);
         assertTrue(newOne.getCreatedOn().isAfter(published.getCreatedOn()));
         
-        ResourceList<StudyConsent> studyConsents2 = client.getAllStudyConsents(researcher.getDefaultSubpopulation());
-        assertEquals(studyConsents.getTotal()+1, studyConsents2.getTotal());
+        ResourceList<StudyConsent> studyConsents2 = client.getAllStudyConsents(subpopGuid);
+        assertEquals(3, studyConsents2.getTotal());
     }
 
 }


### PR DESCRIPTION
- moving methods to developer client from researcher client as consents are now based on developer permissions;
- re-enabled study consent test, using a temporary subpopulation to do the test (so consents can be deleted);
