### PR TITLE
Update study participant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>java-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>develop-SNAPSHOT</version>
+    <version>0.1.0</version>
     <name>BridgeJavaSDK</name>
     <url>https://api.sagebridge.org</url>
     

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
@@ -4,7 +4,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.List;
+
 import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.sdk.models.PagedResourceList;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidVersionHolder;
@@ -19,6 +23,7 @@ import org.sagebionetworks.bridge.sdk.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.sdk.models.users.ExternalIdentifier;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -30,6 +35,8 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
     private final TypeReference<ResourceListImpl<Subpopulation>> subpopType = new TypeReference<ResourceListImpl<Subpopulation>>() {};
     private static final TypeReference<ResourceListImpl<UploadSchema>> TYPE_REF_UPLOAD_SCHEMA_LIST =
             new TypeReference<ResourceListImpl<UploadSchema>>() {};
+    private static final TypeReference<PagedResourceList<ExternalIdentifier>> EXTERNAL_IDENTIFIER_PAGED_RESOURCE_LIST = 
+            new TypeReference<PagedResourceList<ExternalIdentifier>>() {};
 
     BridgeDeveloperClient(BridgeSession session) {
         super(session);
@@ -300,5 +307,27 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
     public void deleteSubpopulation(SubpopulationGuid subpopGuid) {
         session.checkSignedIn();
         delete(config.getSubpopulation(subpopGuid.getGuid()));
+    }
+    @Override
+    public PagedResourceList<ExternalIdentifier> getExternalIds(
+            String offsetKey, Integer pageSize, String idFilter, Boolean assignmentFilter) {
+        session.checkSignedIn();
+        
+        return get(config.getExternalIdsApi(
+                offsetKey, pageSize, idFilter, assignmentFilter), EXTERNAL_IDENTIFIER_PAGED_RESOURCE_LIST);
+    }
+    @Override
+    public void addExternalIds(List<String> externalIdentifiers) {
+        session.checkSignedIn();
+        checkNotNull(externalIdentifiers);
+
+        post(config.getExternalIdsApi(), externalIdentifiers);
+    }
+    @Override
+    public void deleteExternalIds(List<String> externalIdentifiers) {
+        session.checkSignedIn();
+        checkNotNull(externalIdentifiers);
+        
+        delete(config.getExternalIdsApi(externalIdentifiers));
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClient.java
@@ -14,7 +14,7 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
 
     private static final TypeReference<PagedResourceList<AccountSummary>> ACCOUNT_SUMMARY_PAGED_RESOURCE_LIST = 
             new TypeReference<PagedResourceList<AccountSummary>>() {};
-
+                    
     BridgeResearcherClient(BridgeSession session) {
         super(session);
     }
@@ -42,14 +42,19 @@ class BridgeResearcherClient extends BaseApiCaller implements ResearcherClient {
     }
     
     @Override
-    public void updateStudyParticipant(String email, StudyParticipant participant) {
+    public void createStudyParticipant(StudyParticipant participant) {
         session.checkSignedIn();
-        checkArgument(isNotBlank(email), CANNOT_BE_BLANK, "email");
         checkNotNull(participant);
         
-        // It doesn't matter that the participant includes both options and the profile.
-        // Bridge server is lenient about extra properties. It retrieves what it expects.
-        post(config.getParticipantOptionsApi(email), participant);
-        post(config.getParticipantProfileApi(email), participant);
+        post(config.getParticipantsApi(), participant);
+    }
+    
+    @Override
+    public void updateStudyParticipant(StudyParticipant participant) {
+        session.checkSignedIn();
+        checkNotNull(participant);
+        checkArgument(isNotBlank(participant.getEmail()), CANNOT_BE_BLANK, "email");
+        
+        post(config.getParticipantApi(participant.getEmail()), participant);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
@@ -1,6 +1,10 @@
 package org.sagebionetworks.bridge.sdk;
 
+import java.util.List;
+
 import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.sdk.models.PagedResourceList;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidVersionHolder;
@@ -12,6 +16,7 @@ import org.sagebionetworks.bridge.sdk.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.sdk.models.users.ExternalIdentifier;
 
 public interface DeveloperClient {
 
@@ -335,5 +340,37 @@ public interface DeveloperClient {
      * @param subpopGuid
      */
     public void deleteSubpopulation(SubpopulationGuid subpopGuid);
+
+    
+    /**
+     * Get a page of external identifiers added to Bridge. All arguments are optional. 
+     * 
+     * @param offsetKey
+     *      Optional. If provided, records will be returned after this key in the list of identifiers. 
+     *      Similar to an offsetBy index, but not as flexible, this essentially allows you to work page by 
+     *      page through the records. 
+     * @param pageSize
+     *      Number of records to return for this request (1-100 records).
+     * @param idFilter
+     *      Optional string that used to match against the start of an external identifier string
+     * @param assignmentFilter
+     *      Optional boolean filter to return only assigned or unassigned identifiers (if not provided, both 
+     *      are retuend).
+     * @return
+     */
+    public PagedResourceList<ExternalIdentifier> getExternalIds(String offsetKey, Integer pageSize, 
+            String idFilter, Boolean assignmentFilter);
+    
+    /**
+     * Add external identifiers to Bridge. Existing identifiers will be silently ignored.
+     */
+    public void addExternalIds(List<String> externalIdentifiers);
+    
+    /**
+     * Delete external identifiers (only allows if external ID validation is diabled).
+     * 
+     * @param externalIdentifiers
+     */
+    public void deleteExternalIds(List<String> externalIdentifiers);
     
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
@@ -43,11 +43,16 @@ public interface ResearcherClient {
     /**
      * Update an individual study participant. Not all records in study participant can be changed (some 
      * are readonly), and this is reflected in the fields that can be set from the StudyParticipant.Builder.
-     * @param email
-     *      The user's email
      * @param participant
      *      The participant object. The update will be made based on all the values that can be set through 
      *      the StudyParticipant.Builder.
      */
-    void updateStudyParticipant(String email, StudyParticipant participant);
+    void updateStudyParticipant(StudyParticipant participant);
+    
+    /**
+     * Create a study participant.
+     * 
+     * @param participant
+     */
+    void createStudyParticipant(StudyParticipant participant);
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/PagedResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/PagedResourceList.java
@@ -21,33 +21,12 @@ public class PagedResourceList<T> {
     private final Map<String,String> filters = Maps.newHashMap();
 
     @JsonCreator
-    PagedResourceList(
-            @JsonProperty("items") List<T> items, 
-            @JsonProperty("offsetBy") Integer offsetBy,
-            @JsonProperty("pageSize") int pageSize, 
-            @JsonProperty("total") int total) {
+    PagedResourceList(@JsonProperty("items") List<T> items, @JsonProperty("offsetBy") Integer offsetBy,
+            @JsonProperty("pageSize") int pageSize, @JsonProperty("total") int total) {
         this.items = items;
         this.offsetBy = offsetBy;
         this.pageSize = pageSize;
         this.total = total;
-    }
-
-    /**
-     * A convenience method for adding filters without having to construct an intermediate map of filters.
-     * e.g. PagedResourceList<T> page = new PagedResourceList<T>(....).withFilterValue("a","b");
-     */
-    PagedResourceList<T> withFilter(String key, String value) {
-        if (isNotBlank(key) && isNotBlank(value)) {
-            filters.put(key, value);
-        }
-        return this;
-    }
-    /**
-     * Convenience method for adding the DDB key as a filter. The key must be returned to retrieve 
-     * the next page of DDB records.
-     */
-    PagedResourceList<T> withOffsetKey(String offsetKey) {
-        return withFilter(OFFSET_KEY_FILTER, offsetKey);
     }
     public List<T> getItems() {
         return items;

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/PagedResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/PagedResourceList.java
@@ -1,45 +1,82 @@
 package org.sagebionetworks.bridge.sdk.models;
 
-import java.util.List;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 public class PagedResourceList<T> {
+    private static final String OFFSET_KEY_FILTER = "offsetKey";
     private final List<T> items;
-    private final int offsetBy;
+    private final Integer offsetBy;
     private final int pageSize;
     private final int total;
-    private final String emailFilter;
+    private final Map<String,String> filters = Maps.newHashMap();
 
     @JsonCreator
-    public PagedResourceList(@JsonProperty("items") List<T> items, @JsonProperty("offsetBy") int offsetBy,
-            @JsonProperty("limitTo") int pageSize, @JsonProperty("total") int total,
-            @JsonProperty("emailFilter") String emailFilter) {
+    PagedResourceList(
+            @JsonProperty("items") List<T> items, 
+            @JsonProperty("offsetBy") Integer offsetBy,
+            @JsonProperty("pageSize") int pageSize, 
+            @JsonProperty("total") int total) {
         this.items = items;
         this.offsetBy = offsetBy;
         this.pageSize = pageSize;
         this.total = total;
-        this.emailFilter = emailFilter;
+    }
+
+    /**
+     * A convenience method for adding filters without having to construct an intermediate map of filters.
+     * e.g. PagedResourceList<T> page = new PagedResourceList<T>(....).withFilterValue("a","b");
+     */
+    PagedResourceList<T> withFilter(String key, String value) {
+        if (isNotBlank(key) && isNotBlank(value)) {
+            filters.put(key, value);
+        }
+        return this;
+    }
+    /**
+     * Convenience method for adding the DDB key as a filter. The key must be returned to retrieve 
+     * the next page of DDB records.
+     */
+    PagedResourceList<T> withOffsetKey(String offsetKey) {
+        return withFilter(OFFSET_KEY_FILTER, offsetKey);
     }
     public List<T> getItems() {
         return items;
     }
-    public int getTotal() {
-        return total;
-    }
-    public int getOffsetBy() {
+    public Integer getOffsetBy() {
         return offsetBy;
+    }
+    public String getOffsetKey() {
+        return filters.get(OFFSET_KEY_FILTER);
     }
     public int getPageSize() {
         return pageSize;
     }
-    public String getEmailFilter() {
-        return emailFilter;
+    public int getTotal() {
+        return total;
+    }
+    @JsonAnyGetter
+    public Map<String, String> getFilters() {
+        return ImmutableMap.copyOf(filters);
+    }
+    @JsonAnySetter
+    void setFilter(String key, String value) {
+        if (isNotBlank(key) && isNotBlank(value)) {
+            filters.put(key, value);    
+        }
     }
     @Override
     public String toString() {
         return "PagedResourceList [items=" + items + ", offsetBy=" + offsetBy + ", pageSize=" + pageSize + ", total="
-                + total + ", emailFilter=" + emailFilter + "]";
+                + total + ", filters=" + filters + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/accounts/StudyParticipant.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/accounts/StudyParticipant.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.sdk.models.accounts;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.sdk.utils.Utilities.TO_STRING_STYLE;
 
 import java.util.LinkedHashSet;
@@ -14,8 +13,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.sagebionetworks.bridge.sdk.Roles;
 import org.sagebionetworks.bridge.sdk.models.users.SharingScope;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
@@ -26,6 +23,7 @@ public final class StudyParticipant {
     private final String firstName;
     private final String lastName;
     private final String externalId;
+    private final String password;
     private final SharingScope sharingScope;
     private final boolean notifyByEmail;
     private final String email;
@@ -42,7 +40,8 @@ public final class StudyParticipant {
     StudyParticipant(@JsonProperty("firstName") String firstName, 
             @JsonProperty("lastName") String lastName, 
             @JsonProperty("email") String email, 
-            @JsonProperty("externalId") String externalId, 
+            @JsonProperty("externalId") String externalId,
+            @JsonProperty("password") String password,
             @JsonProperty("sharingScope") SharingScope sharingScope,
             @JsonProperty("notifyByEmail") boolean notifyByEmail, 
             @JsonProperty("dataGroups") Set<String> dataGroups, 
@@ -54,6 +53,7 @@ public final class StudyParticipant {
         this.firstName = firstName;
         this.lastName = lastName;
         this.externalId = externalId;
+        this.password = password;
         this.sharingScope = sharingScope;
         this.notifyByEmail = notifyByEmail;
         this.email = email;
@@ -79,6 +79,9 @@ public final class StudyParticipant {
     public String getExternalId() {
         return externalId;
     }
+    public String getPassword() {
+        return password;
+    }
     public SharingScope getSharingScope() {
         return sharingScope;
     }
@@ -91,15 +94,8 @@ public final class StudyParticipant {
     public String getHealthCode() {
         return healthCode;
     }
-    @JsonAnyGetter
     public Map<String,String> getAttributes() {
         return attributes;
-    }
-    @JsonAnySetter
-    public void setAttribute(String name, String value) {
-        if (isNotBlank(name) && isNotBlank(value)) {
-            attributes.put(name, value);
-        }
     }
     public Map<String, List<UserConsentHistory>> getConsentHistories() {
         return consentHistories;
@@ -113,7 +109,7 @@ public final class StudyParticipant {
 
     @Override
     public int hashCode() {
-        return Objects.hash(attributes, consentHistories, dataGroups, email, externalId, firstName, 
+        return Objects.hash(attributes, consentHistories, dataGroups, email, externalId, password, firstName, 
                 lastName, healthCode, languages, notifyByEmail, roles, sharingScope);
     }
 
@@ -126,16 +122,17 @@ public final class StudyParticipant {
         StudyParticipant other = (StudyParticipant) obj;
         return Objects.equals(attributes, other.attributes) && Objects.equals(consentHistories, other.consentHistories)
                 && Objects.equals(dataGroups, other.dataGroups) && Objects.equals(email, other.email)
-                && Objects.equals(externalId, other.externalId) && Objects.equals(firstName, other.firstName)
-                && Objects.equals(healthCode, other.healthCode) && Objects.equals(languages, other.languages)
-                && Objects.equals(lastName, other.lastName) && Objects.equals(notifyByEmail, other.notifyByEmail)
-                && Objects.equals(roles, other.roles) && Objects.equals(sharingScope, other.sharingScope);
+                && Objects.equals(externalId, other.externalId) && Objects.equals(password, other.password)
+                && Objects.equals(firstName, other.firstName) && Objects.equals(healthCode, other.healthCode) 
+                && Objects.equals(languages, other.languages) && Objects.equals(lastName, other.lastName) 
+                && Objects.equals(notifyByEmail, other.notifyByEmail) && Objects.equals(roles, other.roles) 
+                && Objects.equals(sharingScope, other.sharingScope);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, TO_STRING_STYLE).append("firstName", firstName).append("lastName", lastName)
-                .append("externalId", externalId).append("sharingScope", sharingScope)
+                .append("externalId", externalId).append("password", "[REDACTED]").append("sharingScope", sharingScope)
                 .append("notifyByEmail", notifyByEmail).append("email", email).append("healthCode", "[REDACTED]")
                 .append("dataGroups", dataGroups).append("attributes", attributes).append("roles", roles)
                 .append("languages", languages).append("consentHistories", consentHistories).toString();
@@ -144,7 +141,9 @@ public final class StudyParticipant {
     public static class Builder {
         private String firstName;
         private String lastName;
+        private String email;
         private String externalId;
+        private String password;
         private SharingScope sharingScope;
         private boolean notifyByEmail;
         private Set<String> dataGroups = Sets.newHashSet();
@@ -159,8 +158,16 @@ public final class StudyParticipant {
             this.lastName = lastName;
             return this;
         };
+        public Builder withEmail(String email) {
+            this.email = email;
+            return this;
+        };
         public Builder withExternalId(String externalId) {
             this.externalId = externalId;
+            return this;
+        }
+        public Builder withPassword(String password) {
+            this.password = password;
             return this;
         }
         public Builder withSharingScope(SharingScope sharingScope) {
@@ -191,8 +198,8 @@ public final class StudyParticipant {
         }
 
         public StudyParticipant build() {
-            return new StudyParticipant(firstName, lastName, null, externalId, sharingScope, notifyByEmail, dataGroups,
-                    null, attributes, null, null, languages);
+            return new StudyParticipant(firstName, lastName, email, externalId, password, 
+                    sharingScope, notifyByEmail, dataGroups, null, attributes, null, null, languages);
         }
     }    
 }

--- a/src/main/java/org/sagebionetworks/bridge/sdk/models/users/ExternalIdentifier.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/models/users/ExternalIdentifier.java
@@ -5,25 +5,40 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public final class ExternalIdentifier {
     
     private final String identifier;
-    
+    private final boolean isAssigned;
+
     public ExternalIdentifier(String identifier) {
         checkArgument(isNotBlank(identifier), "identifier cannot be null, an empty string or whitespace");
         this.identifier = identifier;
+        this.isAssigned = false;
+    }
+    
+    @JsonCreator
+    ExternalIdentifier(@JsonProperty("identifier") String identifier,
+            @JsonProperty("assigned") boolean isAssigned) {
+        checkArgument(isNotBlank(identifier), "identifier cannot be null, an empty string or whitespace");
+
+        this.identifier = identifier;
+        this.isAssigned = isAssigned;
     }
     
     public String getIdentifier() {
         return identifier;
     }
     
+    public boolean isAssigned() {
+        return isAssigned;
+    }
+    
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Objects.hashCode(identifier);
-        return result;
+        return Objects.hash(identifier, isAssigned);
     }
 
     @Override
@@ -33,7 +48,7 @@ public final class ExternalIdentifier {
         if (obj == null || getClass() != obj.getClass())
             return false;
         ExternalIdentifier other = (ExternalIdentifier) obj;
-        return Objects.equals(identifier, other.identifier);
+        return Objects.equals(identifier, other.identifier) && Objects.equals(isAssigned, other.isAssigned);
     }
 
     @Override

--- a/src/main/resources/bridge-sdk.properties
+++ b/src/main/resources/bridge-sdk.properties
@@ -84,6 +84,8 @@ v3.participant.options = /v3/participants/member/options?email=%s
 v3.participant.profile = /v3/participants/member/profile?email=%s
 v3.participant.signout = /v3/participants/member/signOut?email=%s
 
+v3.external.ids = /v3/externalIds
+
 # Cache Management
 v3.cache = /v3/cache
 v3.cache.cacheKey = /v3/cache/%s

--- a/src/main/resources/bridge-sdk.properties
+++ b/src/main/resources/bridge-sdk.properties
@@ -78,11 +78,11 @@ v3.subpopulations.consents.timestamp = /v3/subpopulations/%s/consents/%s
 v3.subpopulations.consents.timestamp.publish = /v3/subpopulations/%s/consents/%s/publish
 
 # Participants
-v3.participants = /v3/participants?offsetBy=%s&pageSize=%s&emailFilter=%s
-v3.participant = /v3/participants/member?email=%s
-v3.participant.options = /v3/participants/member/options?email=%s
-v3.participant.profile = /v3/participants/member/profile?email=%s
-v3.participant.signout = /v3/participants/member/signOut?email=%s
+v3.participants = /v3/participants
+v3.participant = /v3/participants/member
+v3.participant.options = /v3/participants/member/options
+v3.participant.profile = /v3/participants/member/profile
+v3.participant.signout = /v3/participants/member/signOut
 
 v3.external.ids = /v3/externalIds
 

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/PagedResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/PagedResourceListTest.java
@@ -17,13 +17,14 @@ public class PagedResourceListTest {
         String json = "{'items':["+
                 "{'firstName':'firstName1','lastName':'lastName1','email':'email1@email.com','status':'enabled'},"+
                 "{'firstName':'firstName2','lastName':'lastName2','email':'email2@email.com','status':'disabled'}],"+
-                "'offsetBy': 10,'pageSize': 10,'total': 100,'emailFilter':'foo'}";
+                "'offsetBy': 10,'offsetKey':'aKey','pageSize': 10,'total': 100,'emailFilter':'foo'}";
 
         PagedResourceList<AccountSummary> page = Utilities.getMapper()
                 .readValue(Tests.unescapeJson(json), new TypeReference<PagedResourceList<AccountSummary>>(){});
         assertEquals(new Integer(10), page.getOffsetBy());
         assertEquals(10, page.getPageSize());
         assertEquals(100, page.getTotal());
+        assertEquals("aKey", page.getOffsetKey());
         assertEquals("foo", page.getFilters().get("emailFilter"));
         
         assertEquals(2, page.getItems().size());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/PagedResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/PagedResourceListTest.java
@@ -21,10 +21,10 @@ public class PagedResourceListTest {
 
         PagedResourceList<AccountSummary> page = Utilities.getMapper()
                 .readValue(Tests.unescapeJson(json), new TypeReference<PagedResourceList<AccountSummary>>(){});
-        assertEquals(10, page.getOffsetBy());
+        assertEquals(new Integer(10), page.getOffsetBy());
         assertEquals(10, page.getPageSize());
         assertEquals(100, page.getTotal());
-        assertEquals("foo", page.getEmailFilter());
+        assertEquals("foo", page.getFilters().get("emailFilter"));
         
         assertEquals(2, page.getItems().size());
         

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/StudyParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/StudyParticipantTest.java
@@ -50,13 +50,14 @@ public class StudyParticipantTest {
         consentHistories.put("subpopGuid", Lists.newArrayList(history));
         
         StudyParticipant participant = new StudyParticipant("firstName", "lastName", "email@email.com", "externalId",
-                SharingScope.ALL_QUALIFIED_RESEARCHERS, true, DATA_GROUPS, "healthCode", ATTRIBUTES, consentHistories,
+                "password", SharingScope.ALL_QUALIFIED_RESEARCHERS, true, DATA_GROUPS, "healthCode", ATTRIBUTES, consentHistories,
                 Sets.newHashSet(Roles.DEVELOPER), LANGUAGES);
         
         JsonNode node = Utilities.getMapper().valueToTree(participant);
         assertEquals("firstName", node.get("firstName").asText());
         assertEquals("lastName", node.get("lastName").asText());
         assertEquals("externalId", node.get("externalId").asText());
+        assertEquals("password", node.get("password").asText());
         assertEquals("healthCode", node.get("healthCode").asText());
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, SharingScope.valueOf(node.get("sharingScope").asText().toUpperCase()));
         assertTrue(node.get("notifyByEmail").asBoolean());
@@ -66,10 +67,8 @@ public class StudyParticipantTest {
         assertTrue(DATA_GROUPS.contains(dataGroups.get(0).asText()));
         assertTrue(DATA_GROUPS.contains(dataGroups.get(1).asText()));
         
-        // Note that the property is not on an attributes object, it was added to the 
-        // root JSON object. This is what the server actually expects for extended 
-        // profile attributes.
-        assertEquals("b", node.get("a").asText());
+        JsonNode attrs = node.get("attributes");
+        assertEquals("b", attrs.get("a").asText());
         
         ArrayNode roles = (ArrayNode)node.get("roles");
         assertEquals("developer", roles.get(0).asText());
@@ -102,6 +101,8 @@ public class StudyParticipantTest {
         builder.withFirstName("firstName");
         builder.withLastName("lastName");
         builder.withExternalId("externalId");
+        builder.withEmail("email@email.com");
+        builder.withPassword("password");
         builder.withSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
         builder.withNotifyByEmail(true);
         builder.withDataGroups(DATA_GROUPS);
@@ -112,7 +113,9 @@ public class StudyParticipantTest {
 
         assertEquals("firstName", participant.getFirstName());
         assertEquals("lastName", participant.getLastName());
+        assertEquals("email@email.com", participant.getEmail());
         assertEquals("externalId", participant.getExternalId());
+        assertEquals("password", participant.getPassword());
         assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, participant.getSharingScope());
         assertEquals(true, participant.isNotifyByEmail());
         assertEquals(DATA_GROUPS, participant.getDataGroups());

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/users/ExternalIdentifierTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/users/ExternalIdentifierTest.java
@@ -2,7 +2,14 @@ package org.sagebionetworks.bridge.sdk.models.users;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class ExternalIdentifierTest {
     
@@ -24,6 +31,18 @@ public class ExternalIdentifierTest {
     @Test(expected=IllegalArgumentException.class)
     public void cannotConstructBlankIdentifier() {
         new ExternalIdentifier("   ", false);
+    }
+    
+    @Test
+    public void canSerialize() throws Exception {
+        ExternalIdentifier identifier = new ExternalIdentifier("ABC", true);
+        
+        JsonNode node = Utilities.getMapper().valueToTree(identifier);
+        assertEquals("ABC", node.get("identifier").asText());
+        assertTrue(node.get("assigned").asBoolean());
+        
+        ExternalIdentifier deser = Utilities.getMapper().readValue(node.toString(), ExternalIdentifier.class);
+        assertEquals(identifier, deser);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/models/users/ExternalIdentifierTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/models/users/ExternalIdentifierTest.java
@@ -13,17 +13,17 @@ public class ExternalIdentifierTest {
     
     @Test(expected=IllegalArgumentException.class)
     public void cannotConstructNullIdentifier() {
-        new ExternalIdentifier(null);
+        new ExternalIdentifier(null, false);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void cannotConstructEmptyIdentifier() {
-        new ExternalIdentifier("");
+        new ExternalIdentifier("", false);
     }
     
     @Test(expected=IllegalArgumentException.class)
     public void cannotConstructBlankIdentifier() {
-        new ExternalIdentifier("   ");
+        new ExternalIdentifier("   ", false);
     }
     
 }


### PR DESCRIPTION
- added ability to create, retrieve and delete externalIds;
- added ability to create participants;
- updated StudyParticipants with the fields (email, password) you need to send to create a participant;
- updated PagedResourceList to follow the more flexible design of server object (now returned from two different APIs with different filter criteria);
- added assignment status to ExternalIdentifier;
- refactored the creation of query parameters because it was pretty manual the other way and still possible to create invalid URLs with things like "%s" in them that would throw errors. Relying more on HTTP libraries to do this.
