### PR TITLE
Add ID to session.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/sdk/BridgeSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/BridgeSession.java
@@ -19,6 +19,7 @@ class BridgeSession implements Session {
     private SharingScope sharingScope;
     private String sessionToken;
     private DataGroups dataGroups;
+    private String id;
     private Map<SubpopulationGuid,ConsentStatus> consentStatuses; 
     
     BridgeSession(UserSession session) {
@@ -27,6 +28,7 @@ class BridgeSession implements Session {
         this.sessionToken = session.getSessionToken();
         this.sharingScope = session.getSharingScope();
         this.dataGroups = session.getDataGroups();
+        this.id = session.getId();
         this.consentStatuses = session.getConsentStatuses();
     }
 
@@ -59,6 +61,15 @@ class BridgeSession implements Session {
     
     void setSharingScope(SharingScope sharingScope) {
         this.sharingScope = sharingScope;
+    }
+    
+    @Override
+    public String getId() {
+        return id;
+    }
+    
+    void setId(String id) {
+        this.id = id;
     }
     
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/sdk/Session.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/Session.java
@@ -9,29 +9,31 @@ import org.sagebionetworks.bridge.sdk.models.users.SharingScope;
 
 public interface Session {
 
-    public void checkSignedIn();
+    void checkSignedIn();
 
-    public String getSessionToken();
+    String getSessionToken();
     
-    public SharingScope getSharingScope();
+    SharingScope getSharingScope();
+    
+    String getId();
 
-    public boolean isConsented();
+    boolean isConsented();
     
-    public boolean isSignedIn();
+    boolean isSignedIn();
     
-    public void signOut();
+    void signOut();
     
-    public DataGroups getDataGroups();
+    DataGroups getDataGroups();
     
-    public Map<SubpopulationGuid,ConsentStatus> getConsentStatuses();
+    Map<SubpopulationGuid,ConsentStatus> getConsentStatuses();
     
-    public UserClient getUserClient();
+    UserClient getUserClient();
     
-    public DeveloperClient getDeveloperClient();
+    DeveloperClient getDeveloperClient();
     
-    public ResearcherClient getResearcherClient();
+    ResearcherClient getResearcherClient();
     
-    public AdminClient getAdminClient();
+    AdminClient getAdminClient();
 
     /** Gets the client used for worker APIs. */
     WorkerClient getWorkerClient();

--- a/src/main/java/org/sagebionetworks/bridge/sdk/UserSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/sdk/UserSession.java
@@ -25,6 +25,7 @@ final class UserSession {
     private final String sessionToken;
     private final SharingScope sharingScope;
     private final boolean authenticated;
+    private final String id;
     @JsonDeserialize(using=DataGroupsDeserializer.class)
     @JsonSerialize(using=DataGroupsSerializer.class)
     private final DataGroups dataGroups;
@@ -36,12 +37,14 @@ final class UserSession {
             @JsonProperty("authenticated") boolean authenticated, 
             @JsonProperty("sharingScope") SharingScope sharingScope,
             @JsonProperty("dataGroups") DataGroups dataGroups,
+            @JsonProperty("id") String id,
             @JsonProperty("consentStatuses") Map<SubpopulationGuid,ConsentStatus> consentStatuses) {
         
         this.sessionToken = sessionToken;
         this.authenticated = authenticated;
         this.sharingScope = sharingScope;
         this.dataGroups = dataGroups;
+        this.id = id;
         this.consentStatuses = (consentStatuses == null) ? ImmutableMap.<SubpopulationGuid,ConsentStatus>of() : 
             ImmutableMap.copyOf(consentStatuses);
     }
@@ -70,6 +73,10 @@ final class UserSession {
         return dataGroups;
     }
     
+    public String getId() {
+        return id;
+    }
+    
     public Map<SubpopulationGuid,ConsentStatus> getConsentStatuses() { 
         return consentStatuses;
     }
@@ -80,7 +87,7 @@ final class UserSession {
                 .append("sessionToken", sessionToken).append("authenticated", authenticated)
                 .append("consented", isConsented()).append("sharingScope", sharingScope)
                 .append("signedMostRecentConsent", hasSignedMostRecentConsent()).append("dataGroups", dataGroups)
-                .append("consentStatuses", consentStatuses).toString();
+                .append("id", id).append("consentStatuses", consentStatuses).toString();
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/sdk/UserSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sdk/UserSessionTest.java
@@ -24,6 +24,7 @@ public class UserSessionTest {
         node.put("authenticated", true);
         node.put("consented", false);
         node.put("dataSharing", true);
+        node.put("id", "ABC");
         node.put("sharingScope", "no_sharing");
 
         String json = null;
@@ -43,6 +44,7 @@ public class UserSessionTest {
         assertEquals(session.getSessionToken(), node.get("sessionToken").asText());
         assertEquals(session.isAuthenticated(), node.get("authenticated").asBoolean());
         assertEquals(session.isConsented(), node.get("consented").asBoolean());
+        assertEquals(session.getId(), node.get("id").asText());
         assertEquals(session.getSharingScope().name().toLowerCase(), node.get("sharingScope").asText());
         // We don't pick this up. It's not really necessary, it's there for 100% backwards compatability.
         assertEquals(true, node.get("dataSharing").asBoolean());


### PR DESCRIPTION
This is part of 0.4.1 and needed for the integration tests where we try and retrieve the current user through the participant APIs. (It's also fine to make it available as part of the user's session. Will probably eventually return a study participant object like we do for UserProfile that has all this information).
