### PR TITLE
add URL encoding to Schema APIs

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.8.2</version>
+        <version>0.8.4</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeDeveloperClient.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 
+import com.google.common.net.UrlEscapers;
 import org.joda.time.DateTime;
 
 import org.sagebionetworks.bridge.sdk.models.PagedResourceList;
@@ -255,7 +256,9 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
     public void deleteUploadSchemaAllRevisions(String schemaId) {
         session.checkSignedIn();
         checkArgument(isNotBlank(schemaId), CANNOT_BE_BLANK, "schemaId");
-        delete(config.getUploadSchemaAllRevisionsApi(schemaId));
+
+        String encodedSchemaId = UrlEscapers.urlPathSegmentEscaper().escape(schemaId);
+        delete(config.getUploadSchemaAllRevisionsApi(encodedSchemaId));
     }
 
     @Override
@@ -263,21 +266,27 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
         session.checkSignedIn();
         checkArgument(isNotBlank(schemaId), CANNOT_BE_BLANK, "schemaId");
         checkArgument(revision > 0, "revision must be positive");
-        delete(config.getUploadSchemaApi(schemaId, revision));
+
+        String encodedSchemaId = UrlEscapers.urlPathSegmentEscaper().escape(schemaId);
+        delete(config.getUploadSchemaApi(encodedSchemaId, revision));
     }
 
     @Override
     public ResourceList<UploadSchema> getUploadSchema(String schemaId) {
         session.checkSignedIn();
         checkArgument(isNotBlank(schemaId), CANNOT_BE_BLANK, "schemaId");
-        return get(config.getUploadSchemaAllRevisionsApi(schemaId), TYPE_REF_UPLOAD_SCHEMA_LIST);
+
+        String encodedSchemaId = UrlEscapers.urlPathSegmentEscaper().escape(schemaId);
+        return get(config.getUploadSchemaAllRevisionsApi(encodedSchemaId), TYPE_REF_UPLOAD_SCHEMA_LIST);
     }
     
     @Override
     public UploadSchema getMostRecentUploadSchemaRevision(String schemaId) {
         session.checkSignedIn();
         checkArgument(isNotBlank(schemaId), CANNOT_BE_BLANK, "schemaId");
-        return get(config.getMostRecentUploadSchemaApi(schemaId), UploadSchema.class);
+
+        String encodedSchemaId = UrlEscapers.urlPathSegmentEscaper().escape(schemaId);
+        return get(config.getMostRecentUploadSchemaApi(encodedSchemaId), UploadSchema.class);
     }
 
     @Override
@@ -292,7 +301,9 @@ class BridgeDeveloperClient extends BaseApiCaller implements DeveloperClient {
         checkArgument(isNotBlank(schemaId), CANNOT_BE_BLANK, "schemaId");
         checkArgument(revision > 0, "revision must be positive");
         checkNotNull(schema, CANNOT_BE_NULL, "schema");
-        return post(config.getUploadSchemaV4Api(schemaId, revision), schema, UploadSchema.class);
+
+        String encodedSchemaId = UrlEscapers.urlPathSegmentEscaper().escape(schemaId);
+        return post(config.getUploadSchemaV4Api(encodedSchemaId, revision), schema, UploadSchema.class);
     }
 
     @Override

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeWorkerClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeWorkerClient.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.net.UrlEscapers;
 import org.joda.time.DateTime;
 
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
@@ -31,7 +32,9 @@ class BridgeWorkerClient extends BaseApiCaller implements WorkerClient {
         checkArgument(isNotBlank(studyId), CANNOT_BE_BLANK, "studyId");
         checkArgument(isNotBlank(schemaId), CANNOT_BE_BLANK, "schemaId");
         checkArgument(revision > 0, "revision must be positive");
-        return get(config.getUploadSchemaApi(studyId, schemaId, revision), UploadSchema.class);
+
+        String encodedSchemaId = UrlEscapers.urlPathSegmentEscaper().escape(schemaId);
+        return get(config.getUploadSchemaApi(studyId, encodedSchemaId, revision), UploadSchema.class);
     }
 
     /** {@inheritDoc} */

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.8.2</version>
+    <version>0.8.4</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
Due to historical reasons inherited from the RK/AP, schema IDs can have spaces in them, so we need to encode them.

Additionally, Play Framework only supports %20 in URLs, not + (it's not clear whether that's standard or not), and java.net.URLEncoder encodes spaces as +, so we need to use Guava's UrlEscapers to escape our URLs.

Testing done: Upload Schema Integration Tests (https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/36)
