### PR TITLE
Adding ReportClient and Accept-Language support to go with it.

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.8.7</version>
+        <version>0.8.9</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BaseApiCaller.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BaseApiCaller.java
@@ -66,9 +66,11 @@ class BaseApiCaller {
     private static final String BRIDGE_API_STATUS_HEADER = "Bridge-Api-Status";
     private static final String BRIDGE_SESSION_HEADER = "Bridge-Session";
     private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
     private static final String CONNECTION_FAILED = "Connection to server failed or aborted.";
     protected static final String CANNOT_BE_NULL = "%s cannot be null.";
     protected static final String CANNOT_BE_BLANK = "%s cannot be null, an empty string, or whitespace.";
+    private static final Joiner JOINER = Joiner.on(", ");
     
     // Create an SSL context that does no certificate validation whatsoever.
     private static class DefaultTrustManager implements X509TrustManager {
@@ -277,6 +279,9 @@ class BaseApiCaller {
     private void addApplicationHeaders(Request request) {
         logger.info("User-Agent: " + ClientProvider.getClientInfo().toString());
         request.setHeader(USER_AGENT_HEADER, ClientProvider.getClientInfo().toString());
+        if (!ClientProvider.getLanguages().isEmpty()) {
+            request.setHeader(ACCEPT_LANGUAGE_HEADER, JOINER.join(ClientProvider.getLanguages()));
+        }
         if (session != null && session.isSignedIn()) {
             request.setHeader(BRIDGE_SESSION_HEADER, session.getSessionToken());
         }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeSession.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeSession.java
@@ -135,7 +135,13 @@ class BridgeSession implements Session {
     public UploadSchemaClient getUploadSchemaClient() {
         checkState(isSignedIn(), NOT_AUTHENTICATED);
         return new UploadSchemaClient(this);
-    }    
+    }
+    
+    @Override
+    public ReportClient getReportClient() {
+        checkState(isSignedIn(), NOT_AUTHENTICATED);
+        return new ReportClient(this);
+    }
 
     @Override
     public boolean isSignedIn() {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ClientProvider.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ClientProvider.java
@@ -4,6 +4,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
 import org.sagebionetworks.bridge.sdk.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.sdk.models.accounts.EmailCredentials;
 import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
@@ -13,10 +16,12 @@ import org.sagebionetworks.bridge.sdk.utils.Utilities;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class ClientProvider {
-
+    
     private static final Config config = new Config();
     
     private static ClientInfo info = new ClientInfo.Builder().build();
+    
+    private static LinkedHashSet<String> languages = new LinkedHashSet<>();
     
     /**
      * Retrieve the Config object for the system.
@@ -33,6 +38,23 @@ public class ClientProvider {
     
     public static synchronized void setClientInfo(ClientInfo clientInfo) {
         info = checkNotNull(clientInfo); 
+    }
+    
+    public static void addLanguage(String language) {
+        checkArgument(isNotBlank(language));
+        
+        // Would like to parse and verify this as a LanguageRange object,
+        // which fully supports Accept-Language header syntax. It's a Java 8
+        // feature and we're on Java 7. Put it on the TODO list.
+        languages.add(language);    
+    }
+    
+    public static LinkedHashSet<String> getLanguages() {
+        return Utilities.newLinkedHashSet(languages);
+    }
+    
+    public static void clearLanguages() {
+        languages = new LinkedHashSet<>();
     }
 
     /**

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -568,16 +568,7 @@ public final class Config {
     
     public String getUsersSelfReportsIdentifierApi(String reportId, LocalDate startDate, LocalDate endDate) {
         checkArgument(isNotBlank(reportId));
-        
-        List<NameValuePair> queryParams = Lists.newArrayList();
-        if (startDate != null) {
-            queryParams.add(new BasicNameValuePair(START_DATE, startDate.toString()));
-        }
-        if (endDate != null) {
-            queryParams.add(new BasicNameValuePair(END_DATE, endDate.toString()));
-        }
-        String url = String.format(Props.V3_USERS_SELF_REPORTS_IDENTIFIER.getEndpoint(), reportId);
-        return withQueryParams(url, queryParams);
+        return startEndDateURL(Props.V3_USERS_SELF_REPORTS_IDENTIFIER, reportId, startDate, endDate);
     }
     
     public String getReportsIdentifierApi(String reportId) {
@@ -587,15 +578,7 @@ public final class Config {
     
     public String getReportsIdentifierApi(String reportId, LocalDate startDate, LocalDate endDate) {
         checkArgument(isNotBlank(reportId));
-        List<NameValuePair> queryParams = Lists.newArrayList();
-        if (startDate != null) {
-            queryParams.add(new BasicNameValuePair(START_DATE, startDate.toString()));
-        }
-        if (endDate != null) {
-            queryParams.add(new BasicNameValuePair(END_DATE, endDate.toString()));
-        }
-        String url = String.format(Props.V3_REPORTS_IDENTIFIER.getEndpoint(), reportId);
-        return withQueryParams(url, queryParams);
+        return startEndDateURL(Props.V3_REPORTS_IDENTIFIER, reportId, startDate, endDate);
     }
     
     public String getReportsIdentifierUsersUserIdApi(String reportId, String userId) {
@@ -607,6 +590,18 @@ public final class Config {
     public String getReportsIdentifierUsersApi(String reportId) {
         checkArgument(isNotBlank(reportId));
         return String.format(Props.V3_REPORTS_IDENTIFIER_USERS.getEndpoint(), reportId);
+    }
+    
+    private String startEndDateURL(Props prop, String reportId, LocalDate startDate, LocalDate endDate) {
+        List<NameValuePair> queryParams = Lists.newArrayList();
+        if (startDate != null) {
+            queryParams.add(new BasicNameValuePair(START_DATE, startDate.toString()));
+        }
+        if (endDate != null) {
+            queryParams.add(new BasicNameValuePair(END_DATE, endDate.toString()));
+        }
+        String url = String.format(prop.getEndpoint(), reportId);
+        return withQueryParams(url, queryParams);
     }
     
     private String fromProperty(Props prop) {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -16,6 +16,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
 
 import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
@@ -34,6 +35,8 @@ public final class Config {
     private static final String OFFSET_BY = "offsetBy";
     private static final String OFFSET_KEY = "offsetKey";
     private static final String PAGE_SIZE = "pageSize";
+    private static final String END_DATE = "endDate";
+    private static final String START_DATE = "startDate";
 
     private static final String CONFIG_FILE = "/bridge-sdk.properties";
     private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/bridge-sdk.properties";
@@ -58,59 +61,63 @@ public final class Config {
         V3_AUTH_SIGNOUT("/v3/auth/signOut"), 
         V3_AUTH_SIGNUP("/v3/auth/signUp"), 
         V3_AUTH_VERIFYEMAIL("/v3/auth/verifyEmail"), 
-        V3_BACKFILL_NAME("/v3/backfill/%s"), 
         V3_BACKFILL_NAME_START("/v3/backfill/%s/start"), 
-        V3_CACHE("/v3/cache"), 
+        V3_BACKFILL_NAME("/v3/backfill/%s"), 
         V3_CACHE_CACHEKEY("/v3/cache/%s"),
+        V3_CACHE("/v3/cache"), 
         V3_EXTERNAL_IDS("/v3/externalIds"),
-        V3_PARTICIPANT("/v3/participants/%s"),
         V3_PARTICIPANT_REQUEST_RESET_PASSWORD("/v3/participants/%s/requestResetPassword"),
         V3_PARTICIPANT_SIGNOUT("/v3/participants/%s/signOut"),
-        V3_PARTICIPANTS("/v3/participants"),
+        V3_PARTICIPANT("/v3/participants/%s"),
         V3_PARTICIPANTS_SELF("/v3/participants/self"),
-        V3_SCHEDULEPLANS("/v3/scheduleplans"), 
+        V3_PARTICIPANTS("/v3/participants"),
+        V3_REPORTS_IDENTIFIER_USERS_USERID("/v3/reports/%s/users/%s"),
+        V3_REPORTS_IDENTIFIER_USERS("/v3/reports/%s/users"),
+        V3_REPORTS_IDENTIFIER("/v3/reports/%s"),
         V3_SCHEDULEPLANS_GUID("/v3/scheduleplans/%s"),
-        V3_STUDIES("/v3/studies"), 
+        V3_SCHEDULEPLANS("/v3/scheduleplans"), 
         V3_STUDIES_IDENTIFIER("/v3/studies/%s"),
         V3_STUDIES_SELF("/v3/studies/self"),
         V3_STUDIES_STUDYID_SURVEYS_PUBLISHED("/v3/studies/%s/surveys/published"),
         V3_STUDIES_STUDYID_UPLOADSCHEMAS_SCHEMAID_REVISIONS_REVISION("/v3/studies/%s/uploadschemas/%s/revisions/%d"),
+        V3_STUDIES("/v3/studies"), 
         V3_SUBPOPULATION("/v3/subpopulations/%s"),
-        V3_SUBPOPULATIONS("/v3/subpopulations"),
-        V3_SUBPOPULATIONS_CONSENTS("/v3/subpopulations/%s/consents"),
         V3_SUBPOPULATIONS_CONSENTS_PUBLISHED("/v3/subpopulations/%s/consents/published"),
         V3_SUBPOPULATIONS_CONSENTS_RECENT("/v3/subpopulations/%s/consents/recent"),
-        V3_SUBPOPULATIONS_CONSENTS_SIGNATURE("/v3/subpopulations/%s/consents/signature"),
         V3_SUBPOPULATIONS_CONSENTS_SIGNATURE_EMAIL("/v3/subpopulations/%s/consents/signature/email"),
         V3_SUBPOPULATIONS_CONSENTS_SIGNATURE_WITHDRAW("/v3/subpopulations/%s/consents/signature/withdraw"),
-        V3_SUBPOPULATIONS_CONSENTS_TIMESTAMP("/v3/subpopulations/%s/consents/%s"),
+        V3_SUBPOPULATIONS_CONSENTS_SIGNATURE("/v3/subpopulations/%s/consents/signature"),
         V3_SUBPOPULATIONS_CONSENTS_TIMESTAMP_PUBLISH("/v3/subpopulations/%s/consents/%s/publish"),
-        V3_SURVEYRESPONSES("/v3/surveyresponses"), 
+        V3_SUBPOPULATIONS_CONSENTS_TIMESTAMP("/v3/subpopulations/%s/consents/%s"),
+        V3_SUBPOPULATIONS_CONSENTS("/v3/subpopulations/%s/consents"),
+        V3_SUBPOPULATIONS("/v3/subpopulations"),
         V3_SURVEYRESPONSES_IDENTIFIER("/v3/surveyresponses/%s"), 
-        V3_SURVEYS("/v3/surveys"), 
+        V3_SURVEYRESPONSES("/v3/surveyresponses"), 
         V3_SURVEYS_PUBLISHED("/v3/surveys/published"),
         V3_SURVEYS_RECENT("/v3/surveys/recent"),
-        V3_SURVEYS_SURVEYGUID_REVISIONS("/v3/surveys/%s/revisions"), 
-        V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON("/v3/surveys/%s/revisions/%s"),
         V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON_PHYSICAL_TRUE("/v3/surveys/%s/revisions/%s?physical=true"),
         V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON_PUBLISH("/v3/surveys/%s/revisions/%s/publish"), 
         V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON_VERSION("/v3/surveys/%s/revisions/%s/version"), 
+        V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON("/v3/surveys/%s/revisions/%s"),
         V3_SURVEYS_SURVEYGUID_REVISIONS_PUBLISHED("/v3/surveys/%s/revisions/published"), 
         V3_SURVEYS_SURVEYGUID_REVISIONS_RECENT("/v3/surveys/%s/revisions/recent"), 
+        V3_SURVEYS_SURVEYGUID_REVISIONS("/v3/surveys/%s/revisions"), 
+        V3_SURVEYS("/v3/surveys"), 
+        V3_UPLOADS_UPLOADID_COMPLETE("/v3/uploads/%s/complete"), 
         V3_UPLOADS("/v3/uploads"),
-        V3_UPLOADSCHEMAS("/v3/uploadschemas"),
-        V4_UPLOADSCHEMAS("/v4/uploadschemas"),
-        V3_UPLOADSCHEMAS_SCHEMAID("/v3/uploadschemas/%s"),
         V3_UPLOADSCHEMAS_SCHEMAID_RECENT("/v3/uploadschemas/%s/recent"),
         V3_UPLOADSCHEMAS_SCHEMAID_REVISIONS_REV("/v3/uploadschemas/%s/revisions/%s"),
-        V4_UPLOADSCHEMAS_SCHEMAID_REVISIONS_REV("/v4/uploadschemas/%s/revisions/%d"),
+        V3_UPLOADSCHEMAS_SCHEMAID("/v3/uploadschemas/%s"),
+        V3_UPLOADSCHEMAS("/v3/uploadschemas"),
         V3_UPLOADSTATUSES_UPLOADID("/v3/uploadstatuses/%s"),
-        V3_UPLOADS_UPLOADID_COMPLETE("/v3/uploads/%s/complete"), 
         V3_USER("/v3/users/%s"),
-        V3_USERS("/v3/users"),
         V3_USERS_SELF_EMAILDATA("/v3/users/self/emailData"), 
+        V3_USERS_SELF_REPORTS_IDENTIFIER("/v3/users/self/reports/%s"),
         V3_USERS_SELF_UNSUBSCRIBEEMAIL("/v3/users/self/unsubscribeEmail"), 
-        V4_SCHEDULES("/v4/schedules");
+        V3_USERS("/v3/users"),
+        V4_SCHEDULES("/v4/schedules"),
+        V4_UPLOADSCHEMAS_SCHEMAID_REVISIONS_REV("/v4/uploadschemas/%s/revisions/%d"),
+        V4_UPLOADSCHEMAS("/v4/uploadschemas");
                 
         private String endpoint;
         private Props(String endpoint) {
@@ -511,7 +518,7 @@ public final class Config {
         if (emailFilter != null) {
             queryParams.add(new BasicNameValuePair(EMAIL_FILTER, emailFilter));
         }
-        return withQueryParams(Props.V3_PARTICIPANTS, queryParams);
+        return withQueryParams(Props.V3_PARTICIPANTS.getEndpoint(), queryParams);
     }
     
     public String getParticipantApi(String id) {
@@ -539,7 +546,7 @@ public final class Config {
         for (String id : identifiers) {
             queryParams.add(new BasicNameValuePair(EXTERNAL_ID, id));
         }
-        return withQueryParams(Props.V3_EXTERNAL_IDS, queryParams);
+        return withQueryParams(Props.V3_EXTERNAL_IDS.getEndpoint(), queryParams);
     }
     
     public String getExternalIdsApi(String offsetKey, Integer pageSize, String idFilter, Boolean assignmentFilter) {
@@ -556,7 +563,50 @@ public final class Config {
         if (assignmentFilter != null) {
             queryParams.add(new BasicNameValuePair(ASSIGNMENT_FILTER, assignmentFilter.toString()));
         }
-        return withQueryParams(Props.V3_EXTERNAL_IDS, queryParams);
+        return withQueryParams(Props.V3_EXTERNAL_IDS.getEndpoint(), queryParams);
+    }
+    
+    public String getUsersSelfReportsIdentifierApi(String reportId, LocalDate startDate, LocalDate endDate) {
+        checkArgument(isNotBlank(reportId));
+        
+        List<NameValuePair> queryParams = Lists.newArrayList();
+        if (startDate != null) {
+            queryParams.add(new BasicNameValuePair(START_DATE, startDate.toString()));
+        }
+        if (endDate != null) {
+            queryParams.add(new BasicNameValuePair(END_DATE, endDate.toString()));
+        }
+        String url = String.format(Props.V3_USERS_SELF_REPORTS_IDENTIFIER.getEndpoint(), reportId);
+        return withQueryParams(url, queryParams);
+    }
+    
+    public String getReportsIdentifierApi(String reportId) {
+        checkArgument(isNotBlank(reportId));
+        return String.format(Props.V3_REPORTS_IDENTIFIER.getEndpoint(), reportId);
+    }
+    
+    public String getReportsIdentifierApi(String reportId, LocalDate startDate, LocalDate endDate) {
+        checkArgument(isNotBlank(reportId));
+        List<NameValuePair> queryParams = Lists.newArrayList();
+        if (startDate != null) {
+            queryParams.add(new BasicNameValuePair(START_DATE, startDate.toString()));
+        }
+        if (endDate != null) {
+            queryParams.add(new BasicNameValuePair(END_DATE, endDate.toString()));
+        }
+        String url = String.format(Props.V3_REPORTS_IDENTIFIER.getEndpoint(), reportId);
+        return withQueryParams(url, queryParams);
+    }
+    
+    public String getReportsIdentifierUsersUserIdApi(String reportId, String userId) {
+        checkArgument(isNotBlank(reportId));
+        checkArgument(isNotBlank(userId));
+        return String.format(Props.V3_REPORTS_IDENTIFIER_USERS_USERID.getEndpoint(), reportId, userId);
+    }
+    
+    public String getReportsIdentifierUsersApi(String reportId) {
+        checkArgument(isNotBlank(reportId));
+        return String.format(Props.V3_REPORTS_IDENTIFIER_USERS.getEndpoint(), reportId);
     }
     
     private String fromProperty(Props prop) {
@@ -565,9 +615,9 @@ public final class Config {
         return value.trim();
     }
     
-    private String withQueryParams(Props prop, List<NameValuePair> queryParams) {
+    private String withQueryParams(String endpoint, List<NameValuePair> queryParams) {
         try {
-            URIBuilder builder = new URIBuilder(prop.getEndpoint());
+            URIBuilder builder = new URIBuilder(endpoint);
             builder.addParameters(queryParams);
             return builder.build().toString();
         } catch(URISyntaxException e) {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ReportClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ReportClient.java
@@ -1,0 +1,153 @@
+package org.sagebionetworks.bridge.sdk;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.joda.time.LocalDate;
+
+import org.sagebionetworks.bridge.sdk.models.DateRangeResourceList;
+import org.sagebionetworks.bridge.sdk.models.reports.ReportData;
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Client for working with the report API, an API for saving and retrieving JSON-based data for 
+ * reports, either for a study or for individual participants in a study. Reports are organized by ID, and 
+ * IDs can be added "at will" (you do not need to specify the ID before you start adding data for that 
+ * report). However, report IDs can only contain upper- and lower-case letters, numbers, a dash or 
+ * an underscore.
+ */
+public class ReportClient extends BaseApiCaller {
+
+    private static final TypeReference<DateRangeResourceList<ReportData>> REPORT_DATA_LIST_TYPE = 
+            new TypeReference<DateRangeResourceList<ReportData>>() {};
+
+    ReportClient(BridgeSession session) {
+        super(session);
+    }
+
+    /**
+     * Retrieve a set of report records for a report about the currently authenticated and consented user. 
+     * The date range can span up to 45 days.
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     * @param startDate
+     *      the start date of the records to return (optional, defaults to yesterday)
+     * @param endDate
+     *      the end date of the records to return (optional, default to yesterday)
+     */
+    public DateRangeResourceList<ReportData> getParticipantReport(String reportId, LocalDate startDate,
+            LocalDate endDate) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+        
+        return get(config.getUsersSelfReportsIdentifierApi(reportId, startDate, endDate), REPORT_DATA_LIST_TYPE);
+    }
+    
+    /**
+     * Save a single day of report data for a participant, using the participant's ID.
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     * @param userId
+     *      the ID of the participant
+     * @param reportData
+     *      the data for a single day of the report.
+     */
+    public void saveParticipantReportByUserId(String reportId, String userId, ReportData reportData) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+        checkArgument(isNotBlank(userId), CANNOT_BE_BLANK, "userId");
+        checkNotNull(reportData, CANNOT_BE_NULL, "reportData");
+        
+        post(config.getReportsIdentifierUsersUserIdApi(reportId, userId), reportData);
+    }
+    
+    /**
+     * Save a single day of report data for a participant, using the participant's anonymous health code (necessary 
+     * for reports based on the anonymized data set). Available to accounts with the worker role only.
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     * @param healthCode
+     *      the anonymous health code of a participant
+     * @param reportData
+     *      the data for a single day of the report.
+     */
+    public void saveParticipantReportByHealthCode(String reportId, String healthCode, ReportData reportData) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+        checkArgument(isNotBlank(healthCode), CANNOT_BE_BLANK, "healthCode");
+        checkNotNull(reportData, CANNOT_BE_NULL, "reportData");
+        
+        ObjectNode node = (ObjectNode)Utilities.getMapper().valueToTree(reportData);
+        node.put("healthCode", healthCode);
+        post(config.getReportsIdentifierUsersApi(reportId), node);
+    }
+    
+    /**
+     * Delete all records for all days of a report for a single participant.
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     * @param userId
+     *      the ID of the participant
+     */
+    public void deleteParticipantReport(String reportId, String userId) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+        checkArgument(isNotBlank(userId), CANNOT_BE_BLANK, "healthCode");
+        
+        delete(config.getReportsIdentifierUsersUserIdApi(reportId, userId));
+    }
+    
+    /**
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     * @param startDate
+     *      the start date of the records to return (optional, defaults to yesterday)
+     * @param endDate
+     *      the end date of the records to return (optional, default to yesterday)
+     */
+    public DateRangeResourceList<ReportData> getStudyReport(String reportId, LocalDate startDate, LocalDate endDate) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+        
+        return get(config.getReportsIdentifierApi(reportId, startDate, endDate), REPORT_DATA_LIST_TYPE);
+    }
+
+    /**
+     * Save a single day of report data for study-wide report. This report is available to all consented participants 
+     * in the study.
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     * @param reportData
+     *      the data for a single day of the report.
+     */
+    public void saveStudyReport(String reportId, ReportData reportData) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+        checkNotNull(reportData, CANNOT_BE_NULL, "reportData");
+        
+        post(config.getReportsIdentifierApi(reportId), reportData);
+    }
+    
+    /**
+     * Delete all records for all days of a study-wide report.
+     * 
+     * @param reportId
+     *      the ID of the report in the study
+     */
+    public void deleteStudyReport(String reportId) {
+        session.checkSignedIn();
+        checkArgument(isNotBlank(reportId), CANNOT_BE_BLANK, "reportId");
+
+        delete(config.getReportsIdentifierApi(reportId));
+    }    
+}

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Session.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Session.java
@@ -47,4 +47,6 @@ public interface Session {
     SurveyClient getSurveyClient();
     
     UploadSchemaClient getUploadSchemaClient();
+    
+    ReportClient getReportClient();
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/DateRangeResourceList.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/DateRangeResourceList.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.bridge.sdk.models;
+
+import java.util.List;
+
+import org.joda.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DateRangeResourceList<T> {
+    
+    private final List<T> items;
+    private final int total;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    @JsonCreator
+    DateRangeResourceList(@JsonProperty("items") List<T> items, @JsonProperty("total") int total,
+            @JsonProperty("startDate") LocalDate startDate, @JsonProperty("endDate") LocalDate endDate) {
+        this.items = items;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.total = total;
+    }
+    public List<T> getItems() {
+        return items;
+    }
+    public int getTotal() {
+        return total;
+    }
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+    public LocalDate getEndDate() {
+        return endDate;
+
+    }
+    @Override
+    public String toString() {
+        return "DateRangeResourceList [items=" + items + ", total=" + total + ", startDate=" + startDate + ", endDate="
+                + endDate + "]";
+    }
+}

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/reports/ReportData.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/reports/ReportData.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.bridge.sdk.models.reports;
+
+import org.joda.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ReportData {
+    private final LocalDate date;
+    private final JsonNode reportData;
+    
+    @JsonCreator
+    public ReportData(@JsonProperty("date") LocalDate date, @JsonProperty("data") JsonNode reportData) {
+        this.date = date;
+        this.reportData = reportData;
+    }
+    
+    public LocalDate getDate() {
+        return date;
+    }
+    
+    @JsonProperty("data")
+    public JsonNode getReportData() {
+        return reportData;
+    }
+}

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/utils/Utilities.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/utils/Utilities.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.sdk.utils;
 import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
 import static org.apache.commons.validator.routines.UrlValidator.NO_FRAGMENTS;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -80,5 +81,12 @@ public final class Utilities {
             throw new IllegalArgumentException("URL cannot be null.");
         }
         return urlValidator.isValid(url);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> LinkedHashSet<T> newLinkedHashSet(LinkedHashSet<T> set) {
+        LinkedHashSet<T> copy = new LinkedHashSet<T>();
+        copy.addAll(set);
+        return copy;
     }
 }

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/ClientProviderTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/ClientProviderTest.java
@@ -1,0 +1,33 @@
+package org.sagebionetworks.bridge.sdk;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClientProviderTest {
+    
+    @Before
+    public void before() {
+        ClientProvider.clearLanguages();
+    }
+    
+    @Test
+    public void setLanguage() {
+        ClientProvider.addLanguage("en-US");
+        ClientProvider.addLanguage("fr");
+        
+        LinkedHashSet<String> languages = ClientProvider.getLanguages();
+        
+        Iterator<String> it = languages.iterator();
+        String firstLang = it.next();
+        String secondLang = it.next();
+        
+        assertEquals("en-US", firstLang);
+        assertEquals("fr", secondLang);
+    }
+
+}

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/DateRangeResourceListTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/DateRangeResourceListTest.java
@@ -1,0 +1,48 @@
+package org.sagebionetworks.bridge.sdk.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.Tests;
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+
+public class DateRangeResourceListTest {
+
+    private static final TypeReference<DateRangeResourceList<String>> STRING_LIST_TYPE = 
+            new TypeReference<DateRangeResourceList<String>>() {};
+    private static final ArrayList<String> RESOURCE_ITEMS = Lists.newArrayList("A", "B", "C");
+    private static final LocalDate START_DATE = LocalDate.parse("2016-02-03");
+    private static final LocalDate END_DATE = LocalDate.parse("2016-02-23");
+    
+    @Test
+    public void canSerialize() throws Exception {
+        String json = Tests.unescapeJson("{'items':['A','B','C'],'total':'3','startDate':'2016-02-03','endDate':'2016-02-23','type':'DateRangeResourceList'}");
+
+        JsonNode node = Utilities.getMapper().readTree(json);
+        assertEquals("2016-02-03", node.get("startDate").asText());
+        assertEquals("2016-02-23", node.get("endDate").asText());
+        assertEquals(3, node.get("total").asInt());
+        assertEquals("DateRangeResourceList", node.get("type").asText());
+        assertEquals("A", node.get("items").get(0).asText());
+        assertEquals("B", node.get("items").get(1).asText());
+        assertEquals("C", node.get("items").get(2).asText());
+        assertEquals(5, node.size());
+        
+        DateRangeResourceList<String> desList = Utilities.getMapper().readValue(node.toString(), STRING_LIST_TYPE);
+        
+        assertEquals(RESOURCE_ITEMS, desList.getItems());
+        assertEquals(RESOURCE_ITEMS.size(), desList.getTotal());
+        assertEquals(START_DATE, desList.getStartDate());
+        assertEquals(END_DATE, desList.getEndDate());
+    }
+    
+
+}

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/reports/ReportDataTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/reports/ReportDataTest.java
@@ -1,0 +1,33 @@
+package org.sagebionetworks.bridge.sdk.models.reports;
+
+import static org.junit.Assert.assertEquals;
+
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.Tests;
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ReportDataTest {
+
+    private static final LocalDate REPORT_DATE = LocalDate.parse("2016-06-10");
+    
+    @Test
+    public void canSerialize() throws Exception {
+        String json = Tests.unescapeJson("{'date': '2016-06-10', 'data':{'foo':'baz','bar':'bam'}}");
+        ReportData report = Utilities.getMapper().readValue(json, ReportData.class);
+        
+        assertEquals(REPORT_DATE, report.getDate());
+        assertEquals("baz", report.getReportData().get("foo").asText());
+        assertEquals("bam", report.getReportData().get("bar").asText());
+        
+        JsonNode serReport = Utilities.getMapper().readTree(
+                Utilities.getMapper().writeValueAsString(report));
+        
+        assertEquals(REPORT_DATE.toString(), serReport.get("date").asText());
+        assertEquals("baz", serReport.get("data").get("foo").asText());
+        assertEquals("bam", serReport.get("data").get("bar").asText());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.8.7</version>
+    <version>0.8.9</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
Added report support

Some report end points require that Accept-Language be set, and this was never implemented in the SDK. I've added Basic support for this header (better validation awaits the switch to Java 8 if we do that).
