### PR TITLE
fix fieldDef toString() NullPointerException

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.8.10</version>
+        <version>0.8.11</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinition.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinition.java
@@ -180,7 +180,8 @@ public final class UploadFieldDefinition {
                 ", minAppVersion=" + minAppVersion +
                 ", maxAppVersion=" + maxAppVersion +
                 ", maxLength=" + maxLength +
-                ", maxLength=" + Joiner.on(", ").join(multiChoiceAnswerList) +
+                ", maxLength=" + (multiChoiceAnswerList == null ? "null" :
+                    Joiner.on(", ").useForNull("null").join(multiChoiceAnswerList)) +
                 ", name=" + name +
                 ", required=" + required +
                 ", type=" + type.name() +

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinitionTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinitionTest.java
@@ -43,6 +43,9 @@ public class UploadFieldDefinitionTest {
         assertEquals("happy-case", fieldDef.getName());
         assertTrue(fieldDef.isRequired());
         assertEquals(UploadFieldType.INLINE_JSON_BLOB, fieldDef.getType());
+
+        // test that toString doesn't crash and contains something reasonable
+        assertTrue(fieldDef.toString().contains("happy-case"));
     }
 
     @Test
@@ -104,6 +107,9 @@ public class UploadFieldDefinitionTest {
         assertEquals(multiChoiceAnswerList, fieldDef.getMultiChoiceAnswerList());
         assertEquals("optional-stuff", fieldDef.getName());
         assertEquals(UploadFieldType.STRING, fieldDef.getType());
+
+        // test that toString doesn't crash and contains something reasonable
+        assertTrue(fieldDef.toString().contains("optional-stuff"));
     }
 
     @Test(expected = InvalidEntityException.class)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.8.10</version>
+    <version>0.8.11</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
Fix null-pointer exception in fieldDef.toString().

Also added a simple check for toString() in the happy case test (minimal field-def) and the "optional params" test (maximal field-def).

This is a pre-requisite of:
https://github.com/Sage-Bionetworks/Bridge-Exporter/pull/21
