### PR TITLE
Study uploads reporting

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.9.0</version>
+        <version>0.9.2</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -37,8 +37,6 @@ public final class Config {
     private static final String OFFSET_KEY = "offsetKey";
     private static final String PAGE_SIZE = "pageSize";
     private static final String END_DATE = "endDate";
-    private static final String START_TIME = "startTime";
-    private static final String END_TIME = "endTime";
     private static final String START_DATE = "startDate";
     private static final String START_TIME = "startTime";
     private static final String END_TIME = "endTime";    

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -38,6 +38,8 @@ public final class Config {
     private static final String PAGE_SIZE = "pageSize";
     private static final String END_DATE = "endDate";
     private static final String START_DATE = "startDate";
+    private static final String START_TIME = "startTime";
+    private static final String END_TIME = "endTime";    
     private static final String TYPE = "type";
 
     private static final String CONFIG_FILE = "/bridge-sdk.properties";
@@ -88,6 +90,7 @@ public final class Config {
         V3_SCHEDULEPLANS("/v3/scheduleplans"), 
         V3_STUDIES_IDENTIFIER("/v3/studies/%s"),
         V3_STUDIES_SELF("/v3/studies/self"),
+        V3_STUDIES_UPLOADS("/v3/studies/uploads"),
         V3_STUDIES_STUDYID_SURVEYS_PUBLISHED("/v3/studies/%s/surveys/published"),
         V3_STUDIES_STUDYID_UPLOADSCHEMAS_SCHEMAID_REVISIONS_REVISION("/v3/studies/%s/uploadschemas/%s/revisions/%d"),
         V3_STUDIES("/v3/studies"), 
@@ -476,6 +479,17 @@ public final class Config {
         return Props.V3_STUDIES_SELF.getEndpoint();
     }
 
+    public String getCurrentStudyUploadsApi(DateTime startTime, DateTime endTime) {
+        List<NameValuePair> queryParams = Lists.newArrayList();
+        if (startTime != null) {
+            queryParams.add(new BasicNameValuePair(START_TIME, startTime.toString()));
+        }
+        if (endTime != null) {
+            queryParams.add(new BasicNameValuePair(END_TIME, endTime.toString()));
+        }
+        return withQueryParams(String.format(Props.V3_STUDIES_UPLOADS.getEndpoint()), queryParams);
+    }    
+    
     public String getStudiesApi() {
         return Props.V3_STUDIES.getEndpoint();
     }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -91,7 +91,7 @@ public final class Config {
         V3_SCHEDULEPLANS("/v3/scheduleplans"), 
         V3_STUDIES_IDENTIFIER("/v3/studies/%s"),
         V3_STUDIES_SELF("/v3/studies/self"),
-        V3_STUDIES_UPLOADS("/v3/studies/uploads"),
+        V3_STUDIES_SELF_UPLOADS("/v3/studies/self/uploads"),
         V3_STUDIES_STUDYID_SURVEYS_PUBLISHED("/v3/studies/%s/surveys/published"),
         V3_STUDIES_STUDYID_UPLOADSCHEMAS_SCHEMAID_REVISIONS_REVISION("/v3/studies/%s/uploadschemas/%s/revisions/%d"),
         V3_STUDIES("/v3/studies"), 
@@ -488,7 +488,7 @@ public final class Config {
         if (endTime != null) {
             queryParams.add(new BasicNameValuePair(END_TIME, endTime.toString()));
         }
-        return withQueryParams(String.format(Props.V3_STUDIES_UPLOADS.getEndpoint()), queryParams);
+        return withQueryParams(String.format(Props.V3_STUDIES_SELF_UPLOADS.getEndpoint()), queryParams);
     }    
     
     public String getStudiesApi() {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/StudyClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/StudyClient.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge.sdk;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.holders.SimpleVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.holders.VersionHolder;
@@ -14,7 +16,9 @@ public class StudyClient extends BaseApiCaller {
     
     private static final TypeReference<ResourceList<Study>> STUDY_RESOURCE_LIST = 
             new TypeReference<ResourceList<Study>>() {};
-    
+            
+    private static final TypeReference<DateTimeRangeResourceList<Upload>> UPLOAD_PAGED_RESOURCE_LIST =
+            new TypeReference<DateTimeRangeResourceList<Upload>>() {};    
     StudyClient(BridgeSession session) {
         super(session);
     }
@@ -69,4 +73,25 @@ public class StudyClient extends BaseApiCaller {
         session.checkSignedIn();
         delete(config.getStudyApi(identifier));
     }
+    
+    public void getCurrentStudyUploads() {
+        getCurrentStudyUploadsApi()
+    }
+    
+    /**
+     * Get the uploads for this participant (for up to two days, at any point in time). This upload object is immutable 
+     * information about the status of the upload, from the initial request to whether or not it is successfully uploaded 
+     * and validated.
+     * @param startTime
+     *      An optional start time for the search query (if null, defaults to a day before the end time) 
+     * @param endTime
+     *      An optional end time for the search query (if null, defaults to the time of the request)
+     * @return
+     */
+    public DateTimeRangeResourceList<Upload> getUploads(DateTime startTime, DateTime endTime) {
+        session.checkSignedIn();
+
+        return get(config.getCurrentStudyUploadsApi(startTime, endTime), UPLOAD_PAGED_RESOURCE_LIST);
+    }    
+    
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/StudyClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/StudyClient.java
@@ -78,7 +78,7 @@ public class StudyClient extends BaseApiCaller {
     }
     
     /**
-     * Get the uploads for this participant (for up to two days, at any point in time). This upload object is immutable 
+     * Get the uploads for this study (for up to two days, at any point in time). This upload object is immutable 
      * information about the status of the upload, from the initial request to whether or not it is successfully uploaded 
      * and validated.
      * @param startTime

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.9.0</version>
+    <version>0.9.2</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
StudyClient now has a method to get the study's upload records. This API allows for a reporting process to aggregate information about upload activity in a study.
