### PR TITLE
remove min/maxAppVersion from schema fields

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.9.3</version>
+        <version>0.9.4</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinition.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinition.java
@@ -20,8 +20,6 @@ public final class UploadFieldDefinition {
     private final Boolean allowOtherChoices;
     private final String fileExtension;
     private final String mimeType;
-    private final Integer minAppVersion;
-    private final Integer maxAppVersion;
     private final Integer maxLength;
     private final List<String> multiChoiceAnswerList;
     private final String name;
@@ -35,7 +33,7 @@ public final class UploadFieldDefinition {
      * if we add more fields to this class.
      */
     private UploadFieldDefinition(Boolean allowOtherChoices, String fileExtension, String mimeType,
-            Integer minAppVersion, Integer maxAppVersion, Integer maxLength, List<String> multiChoiceAnswerList,
+            Integer maxLength, List<String> multiChoiceAnswerList,
             String name, boolean required, UploadFieldType type, Boolean unboundedText)
             throws InvalidEntityException {
         if (StringUtils.isBlank(name)) {
@@ -48,8 +46,6 @@ public final class UploadFieldDefinition {
         this.allowOtherChoices = allowOtherChoices;
         this.fileExtension = fileExtension;
         this.mimeType = mimeType;
-        this.minAppVersion = minAppVersion;
-        this.maxAppVersion = maxAppVersion;
         this.maxLength = maxLength;
         this.multiChoiceAnswerList = multiChoiceAnswerList;
         this.name = name;
@@ -71,7 +67,7 @@ public final class UploadFieldDefinition {
      *         if called with invalid fields
      */
     public UploadFieldDefinition(String name, UploadFieldType type) throws InvalidEntityException {
-        this(null, null, null, null, null, null, null, name, true, type, null);
+        this(null, null, null, null, null, name, true, type, null);
     }
 
     /**
@@ -97,22 +93,6 @@ public final class UploadFieldDefinition {
      */
     public String getMimeType() {
         return mimeType;
-    }
-
-    /**
-     * The oldest app version number for which this field is required. App versions before this will treat this field
-     * as optional, as it doesn't exist yet. Does nothing if required is false.
-     */
-    public Integer getMinAppVersion() {
-        return minAppVersion;
-    }
-
-    /**
-     * Similar to minAppVersion. This is used for when required fields are removed from the app, but we want to re-use
-     * the old Synapse table.
-     */
-    public Integer getMaxAppVersion() {
-        return maxAppVersion;
     }
 
     /**
@@ -190,8 +170,6 @@ public final class UploadFieldDefinition {
                 Objects.equals(allowOtherChoices, that.allowOtherChoices) &&
                 Objects.equals(fileExtension, that.fileExtension) &&
                 Objects.equals(mimeType, that.mimeType) &&
-                Objects.equals(minAppVersion, that.minAppVersion) &&
-                Objects.equals(maxAppVersion, that.maxAppVersion) &&
                 Objects.equals(maxLength, that.maxLength) &&
                 Objects.equals(multiChoiceAnswerList, that.multiChoiceAnswerList) &&
                 Objects.equals(name, that.name) &&
@@ -202,7 +180,7 @@ public final class UploadFieldDefinition {
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        return Objects.hash(allowOtherChoices, fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength,
+        return Objects.hash(allowOtherChoices, fileExtension, mimeType, maxLength,
                 multiChoiceAnswerList, name, required, type, unboundedText);
     }
 
@@ -213,8 +191,6 @@ public final class UploadFieldDefinition {
                 ", allowOtherChoices=" + String.valueOf(allowOtherChoices) +
                 ", fileExtension=" + fileExtension +
                 ", mimeType=" + mimeType +
-                ", minAppVersion=" + minAppVersion +
-                ", maxAppVersion=" + maxAppVersion +
                 ", maxLength=" + maxLength +
                 ", maxLength=" + (multiChoiceAnswerList == null ? "null" :
                     Joiner.on(", ").useForNull("null").join(multiChoiceAnswerList)) +
@@ -230,8 +206,6 @@ public final class UploadFieldDefinition {
         private Boolean allowOtherChoices;
         private String fileExtension;
         private String mimeType;
-        private Integer minAppVersion;
-        private Integer maxAppVersion;
         private Integer maxLength;
         private List<String> multiChoiceAnswerList;
         private String name;
@@ -254,18 +228,6 @@ public final class UploadFieldDefinition {
         /** @see org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition#getMimeType */
         public Builder withMimeType(String mimeType) {
             this.mimeType = mimeType;
-            return this;
-        }
-
-        /** @see org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition#getMinAppVersion */
-        public Builder withMinAppVersion(Integer minAppVersion) {
-            this.minAppVersion = minAppVersion;
-            return this;
-        }
-
-        /** @see org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition#getMaxAppVersion */
-        public Builder withMaxAppVersion(Integer maxAppVersion) {
-            this.maxAppVersion = maxAppVersion;
             return this;
         }
 
@@ -332,7 +294,7 @@ public final class UploadFieldDefinition {
                 multiChoiceAnswerListCopy = ImmutableList.copyOf(multiChoiceAnswerList);
             }
 
-            return new UploadFieldDefinition(allowOtherChoices, fileExtension, mimeType, minAppVersion, maxAppVersion, maxLength,
+            return new UploadFieldDefinition(allowOtherChoices, fileExtension, mimeType, maxLength,
                     multiChoiceAnswerListCopy, name, required, type, unboundedText);
         }
     }

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinitionTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinitionTest.java
@@ -96,14 +96,12 @@ public class UploadFieldDefinitionTest {
         List<String> multiChoiceAnswerList = ImmutableList.of("foo", "bar", "baz");
 
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withAllowOtherChoices(true)
-                .withFileExtension(".test").withMimeType("text/plain").withMinAppVersion(10).withMaxAppVersion(13)
+                .withFileExtension(".test").withMimeType("text/plain")
                 .withMaxLength(128).withMultiChoiceAnswerList(multiChoiceAnswerList).withName("optional-stuff")
                 .withType(UploadFieldType.STRING).withUnboundedText(true).build();
         assertTrue(fieldDef.getAllowOtherChoices());
         assertEquals(".test", fieldDef.getFileExtension());
         assertEquals("text/plain", fieldDef.getMimeType());
-        assertEquals(10, fieldDef.getMinAppVersion().intValue());
-        assertEquals(13, fieldDef.getMaxAppVersion().intValue());
         assertEquals(128, fieldDef.getMaxLength().intValue());
         assertEquals(multiChoiceAnswerList, fieldDef.getMultiChoiceAnswerList());
         assertEquals("optional-stuff", fieldDef.getName());
@@ -149,8 +147,6 @@ public class UploadFieldDefinitionTest {
                 "   \"allowOtherChoices\":true,\n" +
                 "   \"fileExtension\":\".json\",\n" +
                 "   \"mimeType\":\"text/json\",\n" +
-                "   \"minAppVersion\":2,\n" +
-                "   \"maxAppVersion\":7,\n" +
                 "   \"maxLength\":24,\n" +
                 "   \"multiChoiceAnswerList\":[\"asdf\", \"jkl;\"],\n" +
                 "   \"name\":\"test-field\",\n" +
@@ -165,8 +161,6 @@ public class UploadFieldDefinitionTest {
         assertTrue(fieldDef.getAllowOtherChoices());
         assertEquals(".json", fieldDef.getFileExtension());
         assertEquals("text/json", fieldDef.getMimeType());
-        assertEquals(2, fieldDef.getMinAppVersion().intValue());
-        assertEquals(7, fieldDef.getMaxAppVersion().intValue());
         assertEquals(24, fieldDef.getMaxLength().intValue());
         assertEquals(expectedAnswerList, fieldDef.getMultiChoiceAnswerList());
         assertEquals("test-field", fieldDef.getName());
@@ -179,12 +173,10 @@ public class UploadFieldDefinitionTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = Utilities.getMapper().readValue(convertedJson, Utilities.TYPE_REF_RAW_MAP);
-        assertEquals(11, jsonMap.size());
+        assertEquals(9, jsonMap.size());
         assertTrue((boolean) jsonMap.get("allowOtherChoices"));
         assertEquals(".json", jsonMap.get("fileExtension"));
         assertEquals("text/json", jsonMap.get("mimeType"));
-        assertEquals(2, jsonMap.get("minAppVersion"));
-        assertEquals(7, jsonMap.get("maxAppVersion"));
         assertEquals(24, jsonMap.get("maxLength"));
         assertEquals(expectedAnswerList, jsonMap.get("multiChoiceAnswerList"));
         assertEquals("test-field", jsonMap.get("name"));

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.9.3</version>
+    <version>0.9.4</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
It was decided that supporting min/maxAppVersion on individual schema fields adds an unsustainable amount of complexity, so we've decided to remove this feature altogether.

First step is to remove it from JavaSDK and Integ tests.

Testing done:
- unit tests pass
