### PR TITLE
add newSchemaRev flag to publish survey

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.10.0</version>
+        <version>0.10.1</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -12,6 +12,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Properties;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicNameValuePair;
@@ -429,11 +430,17 @@ public final class Config {
                 createdOn.toString(ISODateTimeFormat.dateTime()));
     }
 
-    public String getPublishSurveyApi(String guid, DateTime createdOn) {
+    public String getPublishSurveyApi(String guid, DateTime createdOn, boolean newSchemaRev) {
         checkArgument(isNotBlank(guid));
         checkNotNull(createdOn);
-        return String.format(Props.V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON_PUBLISH.getEndpoint(), guid,
+
+        String baseUrl = String.format(Props.V3_SURVEYS_SURVEYGUID_REVISIONS_CREATEDON_PUBLISH.getEndpoint(), guid,
                 createdOn.toString(ISODateTimeFormat.dateTime()));
+
+        List<NameValuePair> queryParams = ImmutableList.<NameValuePair>of(new BasicNameValuePair("newSchemaRev",
+                String.valueOf(newSchemaRev)));
+
+        return withQueryParams(baseUrl, queryParams);
     }
 
     public String getRecentlyPublishedSurveyForUserApi(String guid) {
@@ -624,7 +631,7 @@ public final class Config {
         
         List<NameValuePair> queryParams = Lists.newArrayList();
         queryParams.add(new BasicNameValuePair(TYPE, reportType.name().toLowerCase()));
-        
+
         return withQueryParams(Props.V3_REPORTS.getEndpoint(), queryParams);
     }
     

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
@@ -273,7 +273,7 @@ public class DeveloperClient extends StudyStaffClient {
         session.checkSignedIn();
         checkNotNull(keys, CANNOT_BE_NULL, "guid/createdOn keys");
 
-        return post(config.getPublishSurveyApi(keys.getGuid(), keys.getCreatedOn()), null, 
+        return post(config.getPublishSurveyApi(keys.getGuid(), keys.getCreatedOn(), false), null,
                 SimpleGuidCreatedOnVersionHolder.class);
     }
     

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/SurveyClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/SurveyClient.java
@@ -173,19 +173,36 @@ public class SurveyClient extends BaseApiCaller {
     }
     
     /**
-     * Publish a survey. A published survey is one consented users can see and respond to.
+     * Publish a survey. A published survey is one consented users can see and respond to. Provides the option to cut a
+     * new schema revision or retain the existing schema revision. Note that in some cases, retaining the existing
+     * schema revision is simply not possible. If this happens, a new schema revision will be created transparently.
      *
      * @param keys
-     *            holder object containing a GUID string identifying the survey and DateTime of survey's version.
+     *         holder object containing a GUID string identifying the survey and DateTime of survey's version.
+     * @param newSchemaRevision
+     *         true if you want to cut a new schema revision, false if you want to retain the existing schema
+     * @return updated survey keys
      */
-    public GuidCreatedOnVersionHolder publishSurvey(GuidCreatedOnVersionHolder keys) {
+    public GuidCreatedOnVersionHolder publishSurvey(GuidCreatedOnVersionHolder keys, boolean newSchemaRevision) {
         session.checkSignedIn();
         checkNotNull(keys, CANNOT_BE_NULL, "guid/createdOn keys");
 
-        return post(config.getPublishSurveyApi(keys.getGuid(), keys.getCreatedOn()), null, 
+        return post(config.getPublishSurveyApi(keys.getGuid(), keys.getCreatedOn(), newSchemaRevision), null,
                 SimpleGuidCreatedOnVersionHolder.class);
     }
-    
+
+    /**
+     * Publish a survey. A published survey is one consented users can see and respond to.
+     *
+     * @param keys
+     *         holder object containing a GUID string identifying the survey and DateTime of survey's version.
+     * @return updated survey keys
+     */
+    // This exists for backwards compatibility, but points to the publishSurvey(keys, newSchemaRevision)
+    public GuidCreatedOnVersionHolder publishSurvey(GuidCreatedOnVersionHolder keys) {
+        return publishSurvey(keys, false);
+    }
+
     /**
      * Take the supplied instance of a survey, make it the most recent version of the survey, save it, and then
      * immediately publish it if indicated. This combines several operations for the common case of making trivial fixes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
Add newSchemaRev flag to the publish survey API. This flag controls whether Bridge will (attempt to) retain the existing schema rev or if it will create a new one.

SurveyClient updated with new flag. Old 1-arg publishSurvey() method was kept to avoid breaking changes to downstream consumers.

DeveloperClient was updated to allow it to compile, but the new feature wasn't added to DeveloperClient as it is deprecated.

Testing done:
- compiles
- wrote and ran integration tests (https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/82)
