### PR TITLE
Warnings clean-up: Interface public methods

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.10.1</version>
+        <version>0.10.2</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/GuidCreatedOnVersionHolder.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/GuidCreatedOnVersionHolder.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as=SimpleGuidCreatedOnVersionHolder.class)
 public interface GuidCreatedOnVersionHolder {
-    public String getGuid();
-    public DateTime getCreatedOn();
-    public Long getVersion();
+    String getGuid();
+    DateTime getCreatedOn();
+    Long getVersion();
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/GuidHolder.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/GuidHolder.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as=SimpleGuidHolder.class)
 public interface GuidHolder {
-    public String getGuid();
+    String getGuid();
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/GuidVersionHolder.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/GuidVersionHolder.java
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as=SimpleGuidVersionHolder.class)
 public interface GuidVersionHolder {
-    public String getGuid();
-    public Long getVersion();
+    String getGuid();
+    Long getVersion();
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/IdentifierHolder.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/IdentifierHolder.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as=SimpleIdentifierHolder.class)
 public interface IdentifierHolder {
-    public String getIdentifier();
+    String getIdentifier();
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/VersionHolder.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/holders/VersionHolder.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as=SimpleVersionHolder.class)
 public interface VersionHolder {
-    public Long getVersion();
+    Long getVersion();
 }

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyElement.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyElement.java
@@ -11,9 +11,9 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 })
 public interface SurveyElement {
     
-    public String getGuid();
-    public void setGuid(String guid);
-    public String getIdentifier();
-    public void setIdentifier(String identifier);
+    String getGuid();
+    void setGuid(String guid);
+    String getIdentifier();
+    void setIdentifier(String identifier);
     
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  


### PR DESCRIPTION
No functional change.

Interface methods are implicitly public. These were generating warnings, so I removed the keywords.

Bumped the Maven version number to be on the safe side.

mvn verify (builds, unit test) succeeded. Pulled into a local copy of Integ Tests and ran to verify everything still works.

See also https://sagebionetworks.jira.com/browse/BRIDGE-1461
