### PR TITLE
move build from Artifactory to S3

### DIFF
--- a/api-codegen/pom.xml
+++ b/api-codegen/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.10.5</version>
+        <version>0.10.6</version>
     </parent>
 
     <artifactId>rest-api-codegen</artifactId>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.10.5</version>
+        <version>0.10.6</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.10.5</version>
+    <version>0.10.6</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  
@@ -25,15 +25,6 @@
         <commons-verifier.version>1.4.0</commons-verifier.version>
         <commons-long.version>3.1</commons-long.version>
     </properties>
-
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jcenter-repository</id>
-            <url>http://jcenter.bintray.com</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 
     <dependencyManagement>
         <dependencies>
@@ -118,13 +109,8 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jfrog.buildinfo</groupId>
-                <artifactId>artifactory-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -136,35 +122,23 @@
                         <target>1.7</target>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.jfrog.buildinfo</groupId>
-                    <artifactId>artifactory-maven-plugin</artifactId>
-                    <version>2.2.2</version>
-                    <inherited>true</inherited>
-                    <executions>
-                        <execution>
-                            <id>build-info</id>
-                            <goals>
-                                <goal>publish</goal>
-                            </goals>
-                            <configuration>
-                                <deployProperties>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                </deployProperties>
-                                <publisher>
-                                    <contextUrl>http://sagebionetworks.artifactoryonline.com/sagebionetworks</contextUrl>
-                                    <username>${env.ARTIFACTORY_USERNAME}</username>
-                                    <password>${env.ARTIFACTORY_PASSWORD}</password>
-                                    <repoKey>libs-releases-local</repoKey>
-                                    <snapshotRepoKey>libs-snapshots-local</snapshotRepoKey>
-                                </publisher>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
+
+        <extensions>
+            <extension>
+                <groupId>org.springframework.build</groupId>
+                <artifactId>aws-maven</artifactId>
+                <version>5.0.0.RELEASE</version>
+            </extension>
+        </extensions>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>org-sagebridge-repo-maven-releases</id>
+            <name>org-sagebridge-repo-maven-releases</name>
+            <url>s3://org-sagebridge-repo-maven-releases</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Tested with dummy version 0.10.5.djengtest and running mvn clean deploy locally. Verified by checking output in S3 bucket org-sagebridge-repo-maven-releases

Next steps:
- update Travis build
- update BridgeIntegrationTests (and other packages) to pull new versions from this repo instead of Artifactory
