### PR TITLE
use maven-s3-wagon for both repo and docs

### DIFF
--- a/api-codegen/pom.xml
+++ b/api-codegen/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.10.6</version>
+        <version>0.10.7</version>
     </parent>
 
     <artifactId>rest-api-codegen</artifactId>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.sagebionetworks.bridge</groupId>
         <artifactId>sdk-group</artifactId>
         <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-        <version>0.10.6</version>
+        <version>0.10.7</version>
     </parent>
 
     <!-- groupId and version are inherited from parent pom -->
@@ -19,7 +19,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <surefire.version>2.18.1</surefire.version>
         <javadoc.version>2.10.4</javadoc.version>
-        <maven-s3-wagon.version>1.2.1</maven-s3-wagon.version>
     </properties>
 
     <organization>
@@ -137,14 +136,4 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <build>
-        <extensions>
-            <extension>
-                <groupId>org.kuali.maven.wagons</groupId>
-                <artifactId>maven-s3-wagon</artifactId>
-                <version>${maven-s3-wagon.version}</version>
-            </extension>            
-        </extensions>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.10.6</version>
+    <version>0.10.7</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
  
@@ -127,17 +127,16 @@
 
         <extensions>
             <extension>
-                <groupId>org.springframework.build</groupId>
-                <artifactId>aws-maven</artifactId>
-                <version>5.0.0.RELEASE</version>
+                <groupId>org.kuali.maven.wagons</groupId>
+                <artifactId>maven-s3-wagon</artifactId>
+                <version>1.2.1</version>
             </extension>
         </extensions>
     </build>
 
     <distributionManagement>
         <repository>
-            <id>org-sagebridge-repo-maven-releases</id>
-            <name>org-sagebridge-repo-maven-releases</name>
+            <id>s3.release</id>
             <url>s3://org-sagebridge-repo-maven-releases</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
As it turns out, maven-s3-wagon and aws-maven interfere with each other. aws-maven can only be used for repo, not docs. Luckily, maven-s3-wagon can be used for both.

This change pulls maven-s3-wagon to the parent project and fixes the build. Tested this by running mvn clean deploy on the parent project and mvn site site:deploy on the java-sdk project and verified that everything builds into a test version.
