### PR TITLE
This undoes changes to make the existing classes use the new autogenerated classes.

### DIFF
--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/AdminClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/AdminClient.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.bridge.sdk;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.List;
 
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
@@ -12,10 +14,8 @@ import org.sagebionetworks.bridge.sdk.models.studies.Study;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public final class AdminClient extends StudyStaffClient {
     

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BaseApiCaller.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BaseApiCaller.java
@@ -1,43 +1,5 @@
 package org.sagebionetworks.bridge.sdk;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Joiner;
-
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.ParseException;
-import org.apache.http.StatusLine;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.fluent.Executor;
-import org.apache.http.client.fluent.Request;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.http.util.EntityUtils;
-import org.sagebionetworks.bridge.sdk.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
-import org.sagebionetworks.bridge.sdk.exceptions.ConcurrentModificationException;
-import org.sagebionetworks.bridge.sdk.exceptions.ConsentRequiredException;
-import org.sagebionetworks.bridge.sdk.exceptions.EntityAlreadyExistsException;
-import org.sagebionetworks.bridge.sdk.exceptions.EntityNotFoundException;
-import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.sdk.exceptions.NotAuthenticatedException;
-import org.sagebionetworks.bridge.sdk.exceptions.PublishedSurveyException;
-import org.sagebionetworks.bridge.sdk.exceptions.UnauthorizedException;
-import org.sagebionetworks.bridge.sdk.exceptions.UnsupportedVersionException;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadRequest;
-import org.sagebionetworks.bridge.sdk.rest.ApiClientProvider;
-import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
-import org.sagebionetworks.bridge.sdk.utils.Utilities;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -54,8 +16,42 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import retrofit2.Call;
-import retrofit2.Response;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ParseException;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.sagebionetworks.bridge.sdk.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.sdk.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.sdk.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.sdk.exceptions.EntityAlreadyExistsException;
+import org.sagebionetworks.bridge.sdk.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.sdk.exceptions.NotAuthenticatedException;
+import org.sagebionetworks.bridge.sdk.exceptions.PublishedSurveyException;
+import org.sagebionetworks.bridge.sdk.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.sdk.exceptions.UnsupportedVersionException;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadRequest;
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
 
 class BaseApiCaller {
 
@@ -69,12 +65,7 @@ class BaseApiCaller {
     protected static final String CANNOT_BE_NULL = "%s cannot be null.";
     protected static final String CANNOT_BE_BLANK = "%s cannot be null, an empty string, or whitespace.";
     private static final Joiner JOINER = Joiner.on(", ");
-    protected static final ApiClientProvider API_CLIENT_PROVIDER = new ApiClientProvider(
-        ClientProvider.getConfig().getEnvironment()
-                      .getUrl(),
-        ClientProvider.getClientInfo().toString()
-    );
-
+    
     // Create an SSL context that does no certificate validation whatsoever.
     private static class DefaultTrustManager implements X509TrustManager {
         @Override
@@ -106,9 +97,6 @@ class BaseApiCaller {
 
     private final ObjectMapper mapper = Utilities.getMapper();
 
-    protected final SignIn signIn;
-
-    @Deprecated
     protected BridgeSession session;
 
     protected final Config config = ClientProvider.getConfig();
@@ -116,50 +104,59 @@ class BaseApiCaller {
     protected BaseApiCaller(BridgeSession session) {
         //checkNotNull(session); no session when used for sign in/sign out/reset password
         this.session = session;
-        this.signIn = session == null ? null : session.getSignIn();
-    }
-
-    protected <T> T call(Call<T> call) {
-        return call(call, null);
-    }
-
-    protected <T> T call(Call<T> call, SignIn signIn) {
-        try {
-            Response<T> response = call.execute();
-
-            throwExceptionOnErrorStatus(response, call.request().url().toString(), signIn);
-
-            return response.body();
-        } catch (IOException e) {
-            throw new BridgeSDKException(CONNECTION_FAILED, e);
-        }
     }
 
     protected HttpResponse publicGet(String url) {
         url = getFullUrl(url);
+        try {
 
-        logger.debug("GET {}", url);
-        Request request = Request.Get(url);
-        return executeRequest(request, url, null);
+            logger.debug("GET {}", url);
+            Request request = Request.Get(url);
+            HttpResponse response = exec.execute(request).returnResponse();
+            throwExceptionOnErrorStatus(response, url);
+            return response;
+
+        } catch (ClientProtocolException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        } catch (IOException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        }
     }
 
     protected HttpResponse s3Put(String url, HttpEntity entity, UploadRequest uploadRequest) {
-        logger.debug("PUT {}\n    <BINARY DATA>", url);
-        Request request = Request.Put(url).body(entity);
-        request.addHeader("Content-Type", uploadRequest.getContentType());
-        request.addHeader("Content-MD5", uploadRequest.getContentMd5());
+        try {
 
-        return executeRequest(request, url, null);
+            logger.debug("PUT {}\n    <BINARY DATA>", url);
+            Request request = Request.Put(url).body(entity);
+            request.addHeader("Content-Type", uploadRequest.getContentType());
+            request.addHeader("Content-MD5", uploadRequest.getContentMd5());
+            HttpResponse response = request.execute().returnResponse();
+            throwExceptionOnErrorStatus(response, url);
+            return response;
+
+        } catch (ClientProtocolException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        } catch (IOException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        }
     }
 
     protected HttpResponse get(String url) {
         url = getFullUrl(url);
+        try {
 
-        Request request = Request.Get(url);
-        addApplicationHeaders(request);
-        logger.debug("GET {}", url);
+            Request request = Request.Get(url);
+            addApplicationHeaders(request);
+            logger.debug("GET {}", url);
+            HttpResponse response = exec.execute(request).returnResponse();
+            throwExceptionOnErrorStatus(response, url);
+            return response;
 
-        return executeRequest(request, url, null);
+        } catch (ClientProtocolException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        } catch (IOException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        }
     }
 
     protected <T> T get(String url, TypeReference<T> type) {
@@ -174,17 +171,25 @@ class BaseApiCaller {
 
     protected HttpResponse post(String url) {
         url = getFullUrl(url);
+        try {
 
-        Request request = Request.Post(url);
-        addApplicationHeaders(request);
-        logger.debug("POST {}\n    <EMPTY>", url);
+            Request request = Request.Post(url);
+            addApplicationHeaders(request);
+            logger.debug("POST {}\n    <EMPTY>", url);
+            HttpResponse response = exec.execute(request).returnResponse();
+            throwExceptionOnErrorStatus(response, url);
+            return response;
 
-        return executeRequest(request, url, null);
+        } catch (ClientProtocolException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        } catch (IOException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        }
     }
 
     protected HttpResponse post(String url, Object object) {
         try {
-            return postJSON(url, mapper.writeValueAsString(object), null);
+            return postJSON(url, mapper.writeValueAsString(object));
 
         } catch (JsonProcessingException e) {
             String message = String.format("Could not process %s: %s", object.getClass().getSimpleName(), object.toString());
@@ -193,54 +198,63 @@ class BaseApiCaller {
     }
 
     protected <T> T post(String url, Object object, TypeReference<T> type) {
-        String json = Utilities.getObjectAsJson(object);
-        HttpResponse response = postJSON(url, json, null);
-        return getResponseBodyAsType(response, type);
-    }
+        try {
 
-    protected <T> T post(String url, Object object, Class<T> clazz) {
-        return post(url, object, clazz, null);
-    }
+            String json = mapper.writeValueAsString(object);
+            HttpResponse response = postJSON(url, json);
+            return getResponseBodyAsType(response, type);
 
-    protected <T> T post(String url, Object object, Class<T> clazz, SignIn signIn) {
-        String json = (object != null) ? Utilities.getObjectAsJson(object) : null;
-
-        HttpResponse response = postJSON(url, json, signIn);
-        return getResponseBodyAsType(response, clazz);
-    }
-
-    private HttpResponse postJSON(String url, String json, SignIn signIn) {
-        url = getFullUrl(url);
-
-        Request request = Request.Post(url);
-        addApplicationHeaders(request);
-        if (json != null) {
-            request.bodyString(json, ContentType.APPLICATION_JSON);
-            logger.debug("POST {} \n     {}", url, maskPassword(json));
-        } else {
-            logger.debug("POST {}", url);
+        } catch (JsonProcessingException e) {
+            String message = String.format("Could not process %s: %s", object.getClass().getSimpleName(), object.toString());
+            throw new BridgeSDKException(message, e);
         }
+    }
+    
+    protected <T> T post(String url, Object object, Class<T> clazz) {
+        try {
 
-        return executeRequest(request, url, signIn);
+            String json = (object != null) ? mapper.writeValueAsString(object) : null;
+            HttpResponse response = postJSON(url, json);
+            return (clazz != null) ? getResponseBodyAsType(response, clazz) : null;
+
+        } catch (JsonProcessingException e) {
+            String message = String.format("Could not process %s: %s", object.getClass().getSimpleName(), object.toString());
+            throw new BridgeSDKException(message, e);
+        }
+    }
+
+    private HttpResponse postJSON(String url, String json) {
+        url = getFullUrl(url);
+        try {
+
+            Request request = Request.Post(url);
+            addApplicationHeaders(request);
+            if (json != null) {
+                request.bodyString(json, ContentType.APPLICATION_JSON);
+                logger.debug("POST {} \n     {}", url, maskPassword(json));
+            } else {
+                logger.debug("POST {}", url);
+            }
+            HttpResponse response = exec.execute(request).returnResponse();
+            throwExceptionOnErrorStatus(response, url);
+            return response;
+
+        } catch (IOException e) {
+            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+        }
     }
 
     protected HttpResponse delete(String url) {
         url = getFullUrl(url);
 
-        Request request = Request.Delete(url);
-        addApplicationHeaders(request);
-        logger.debug("DELETE {}", url);
-
-        return executeRequest(request, url, null);
-    }
-
-    private HttpResponse executeRequest(Request request, String url, SignIn signIn) {
         try {
+            Request request = Request.Delete(url);
+            addApplicationHeaders(request);
+            logger.debug("DELETE {}", url);
             HttpResponse response = exec.execute(request).returnResponse();
-            throwExceptionOnErrorStatus(response, url, signIn);
+            throwExceptionOnErrorStatus(response, url);
             return response;
-        } catch (ClientProtocolException e) {
-            throw new BridgeSDKException(CONNECTION_FAILED, e, url);
+
         } catch (IOException e) {
             throw new BridgeSDKException(CONNECTION_FAILED, e, url);
         }
@@ -269,12 +283,24 @@ class BaseApiCaller {
 
     private <T> T getResponseBodyAsType(HttpResponse response, Class<T> c) {
         String responseBody = getResponseBody(response);
-        return Utilities.getJsonAsType(responseBody, c);
+        try {
+            return mapper.readValue(responseBody, c);
+        } catch (IOException e) {
+            throw new BridgeSDKException("Error message: " + e.getMessage()
+                    + "\nSomething went wrong while converting Response Body JSON into " + c.getSimpleName()
+                    + ": responseBody=" + responseBody, e);
+        }
     }
 
     private <T> T getResponseBodyAsType(HttpResponse response, TypeReference<T> type) {
         String responseBody = getResponseBody(response);
-        return Utilities.getJsonAsType(responseBody, type);
+        try {
+            return mapper.readValue(responseBody, type);
+        } catch (IOException e) {
+            throw new BridgeSDKException("Error message: " + e.getMessage()
+                    + "\nSomething went wrong while converting Response Body JSON into " + type.getType().getClass().getSimpleName()
+                    + ": responseBody=" + responseBody, e);
+        }
     }
 
     private JsonNode getJsonNode(HttpResponse response) {
@@ -288,38 +314,8 @@ class BaseApiCaller {
         }
     }
 
-    private void throwExceptionOnErrorStatus(Response response, String url, SignIn signIn) {
-        Object body = response.isSuccessful() ? response.body() : response.errorBody();
-        try {
-            logger.debug("{} RESPONSE: {}", response.code(), body);
-        } catch (Exception e) {
-            logger.debug("{} RESPONSE: <ERROR>", response.code());
-        }
-
-        List<String> statusHeaders = response.headers().toMultimap().get(BRIDGE_API_STATUS_HEADER);
-        if (statusHeaders != null && statusHeaders.size() > 0 &&
-            "deprecated".equals(statusHeaders.get(0))) {
-            logger.warn(url +
-                        " is a deprecated API. This API may return 410 (Gone) at a future date. " +
-                        "Please consult the API documentation for an alternative.");
-        }
-        if (response.isSuccessful()) {
-            return;
-        }
-
-        try {
-            JsonNode node = mapper.readTree(response.errorBody().string());
-            throwExceptionOnErrorStatus(url, response.code(), node, signIn);
-        } catch (BridgeSDKException e) {
-            // rethrow known exceptions
-            throw e;
-        } catch (Throwable t) {
-            t.printStackTrace();
-            throw new BridgeSDKException(response.message(), response.code(), url);
-        }
-    }
-
-    private void throwExceptionOnErrorStatus(HttpResponse response, String url, SignIn signIn) {
+    @SuppressWarnings("unchecked")
+    private void throwExceptionOnErrorStatus(HttpResponse response, String url) {
         try {
             logger.debug("{} RESPONSE: {}", response.getStatusLine().getStatusCode(), EntityUtils.toString(response.getEntity()));
         } catch(IOException e) {
@@ -335,77 +331,52 @@ class BaseApiCaller {
         StatusLine status = response.getStatusLine();
         int statusCode = status.getStatusCode();
         if (statusCode < 200 || statusCode > 299) {
+            BridgeSDKException e = null;
             try {
                 JsonNode node = getJsonNode(response);
-                throwExceptionOnErrorStatus(url, statusCode, node, signIn);
-            } catch (BridgeSDKException e) {
-                // rethrow known exceptions
-                throw e;
-            } catch (Throwable t) {
+
+                // Not having a message is actually pretty bad
+                String message = "There has been an error on the server";
+                if (node.has("message")) {
+                    message = node.get("message").asText();
+                }
+                if (statusCode == 401) {
+                    e = new NotAuthenticatedException(message, url);
+                } else if (statusCode == 403) {
+                    e = new UnauthorizedException(message, url);
+                } else if (statusCode == 404 && message.length() > "not found.".length()) {
+                    e = new EntityNotFoundException(message, url);
+                } else if (statusCode == 410) {
+                    e = new UnsupportedVersionException(message, url);
+                } else if (statusCode == 412) {
+                    UserSession session = getResponseBodyAsType(response, UserSession.class);
+                    e = new ConsentRequiredException("Consent required.", url, new BridgeSession(session));
+                } else if (statusCode == 409 && message.contains("already exists")) {
+                    e = new EntityAlreadyExistsException(message, url);
+                } else if (statusCode == 409 && message.contains("has the wrong version number")) {
+                    e = new ConcurrentModificationException(message, url);
+                } else if (statusCode == 400 && message.contains("A published survey")) {
+                    e = new PublishedSurveyException(message, url);
+                } else  if (statusCode == 400 && node.has("errors")) {
+                    Map<String, List<String>> errors = (Map<String, List<String>>) mapper.convertValue(
+                            node.get("errors"), new TypeReference<HashMap<String, ArrayList<String>>>() {});
+                    e = new InvalidEntityException(message, errors, url);
+                } else if (statusCode == 400) {
+                    e = new BadRequestException(message, url);
+                } else {
+                    e = new BridgeSDKException(message, status.getStatusCode(), url);
+                }
+            } catch(Throwable t) {
                 t.printStackTrace();
                 throw new BridgeSDKException(status.getReasonPhrase(), status.getStatusCode(), url);
             }
+            throw e;
         }
-    }
-    /**
-     * @param signIn
-     *          credentials to be used for creating a BridgeSession for when a 412 is thrown,
-     *          this is used for performing a signIn. If not performing a sign in, this.signIn
-     *          should exist because we are already in a session and signed in since we are
-     *          getting a 412.
-     */
-    private void throwExceptionOnErrorStatus(
-            String url, int statusCode, JsonNode node, SignIn signIn
-    ) {
-
-        // Not having a message is actually pretty bad
-        String message = "There has been an error on the server";
-        if (node.has("message")) {
-            message = node.get("message").asText();
-        }
-
-        BridgeSDKException e;
-        if (statusCode == 401) {
-            e = new NotAuthenticatedException(message, url);
-        } else if (statusCode == 403) {
-            e = new UnauthorizedException(message, url);
-        } else if (statusCode == 404 && message.length() > "not found.".length()) {
-            e = new EntityNotFoundException(message, url);
-        } else if (statusCode == 410) {
-            e = new UnsupportedVersionException(message, url);
-        } else if (statusCode == 412) {
-            UserSession session = Utilities.getJsonAsType(node, UserSession.class);
-            e = new ConsentRequiredException(
-                    "Consent required.",
-                    url,
-                    new BridgeSession(
-                            session,
-                            signIn != null ? signIn : this.signIn
-                    )
-            );
-        } else if (statusCode == 409 && message.contains("already exists")) {
-            e = new EntityAlreadyExistsException(message, url);
-        } else if (statusCode == 409 && message.contains("has the wrong version number")) {
-            e = new ConcurrentModificationException(message, url);
-        } else if (statusCode == 400 && message.contains("A published survey")) {
-            e = new PublishedSurveyException(message, url);
-        } else if (statusCode == 400 && node.has("errors")) {
-            Map<String, List<String>> errors = mapper.convertValue(
-                    node.get("errors"),
-                    new TypeReference<HashMap<String, ArrayList<String>>>() { }
-            );
-            e = new InvalidEntityException(message, errors, url);
-        } else if (statusCode == 400) {
-            e = new BadRequestException(message, url);
-        } else {
-            e = new BridgeSDKException(message, statusCode, url);
-        }
-        throw e;
     }
 
     private String getFullUrl(String url) {
         assert url != null;
-
+        
         String fullUrl = config.getEnvironment().getUrl() + url;
         assert Utilities.isValidUrl(fullUrl) : fullUrl;
         return fullUrl;

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeSession.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/BridgeSession.java
@@ -3,15 +3,14 @@ package org.sagebionetworks.bridge.sdk;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 import org.sagebionetworks.bridge.sdk.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.ConsentStatus;
 import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
-import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 
 class BridgeSession implements Session {
 
@@ -19,21 +18,12 @@ class BridgeSession implements Session {
 
     private String sessionToken;
     private StudyParticipant participant;
-    private Map<SubpopulationGuid,ConsentStatus> consentStatuses;
-
-    private final SignIn signIn;
+    private Map<SubpopulationGuid,ConsentStatus> consentStatuses; 
     
-    BridgeSession(UserSession session, SignIn signIn) {
+    BridgeSession(UserSession session) {
         checkNotNull(session, "%s cannot be null", "UserSession");
-        checkNotNull(signIn, "signIn cannot be null");
-
+        
         setUserSession(session);
-        this.signIn = signIn;
-        StudyParticipant studyParticipant = session.getStudyParticipant();
-    }
-
-    public SignIn getSignIn() {
-        return signIn;
     }
 
     /**

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ClientProvider.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ClientProvider.java
@@ -4,25 +4,24 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedHashSet;
 
 import org.sagebionetworks.bridge.sdk.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.sdk.models.accounts.EmailCredentials;
 import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
 import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
-import java.util.LinkedHashSet;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class ClientProvider {
-
+    
     private static final Config config = new Config();
-
+    
     private static ClientInfo info = new ClientInfo.Builder().build();
-
+    
     private static LinkedHashSet<String> languages = new LinkedHashSet<>();
-
+    
     /**
      * Retrieve the Config object for the system.
      *
@@ -31,28 +30,28 @@ public class ClientProvider {
     public static Config getConfig() {
         return config;
     }
-
+    
     public static ClientInfo getClientInfo() {
         return info;
     }
-
+    
     public static synchronized void setClientInfo(ClientInfo clientInfo) {
-        info = checkNotNull(clientInfo);
+        info = checkNotNull(clientInfo); 
     }
-
+    
     public static void addLanguage(String language) {
         checkArgument(isNotBlank(language));
-
+        
         // Would like to parse and verify this as a LanguageRange object,
         // which fully supports Accept-Language header syntax. It's a Java 8
         // feature and we're on Java 7. Put it on the TODO list.
-        languages.add(language);
+        languages.add(language);    
     }
-
+    
     public static LinkedHashSet<String> getLanguages() {
         return Utilities.newLinkedHashSet(languages);
     }
-
+    
     public static void clearLanguages() {
         languages = new LinkedHashSet<>();
     }
@@ -64,18 +63,11 @@ public class ClientProvider {
      *            The credentials you wish to sign in with.
      * @return Session
      */
-    public static Session signIn(SignInCredentials signInCredentials) throws
-            ConsentRequiredException {
-        checkNotNull(signInCredentials, "SignInCredentials required.");
+    public static Session signIn(SignInCredentials signIn) throws ConsentRequiredException {
+        checkNotNull(signIn, "SignInCredentials required.");
 
-        SignIn signIn = new SignIn().study(signInCredentials.getStudyIdentifier())
-                                    .email(signInCredentials.getEmail())
-                                    .password(signInCredentials.getPassword());
-
-        UserSession userSession = new BaseApiCaller(null).post(config.getSignInApi(),
-                                                               signInCredentials, UserSession
-                                                                       .class, signIn);
-        return new BridgeSession(userSession, signIn);
+        UserSession userSession = new BaseApiCaller(null).post(config.getSignInApi(), signIn, UserSession.class);
+        return new BridgeSession(userSession);
     }
 
     /**
@@ -85,7 +77,7 @@ public class ClientProvider {
      *      The identifier of the study the participant is signing up with
      * @param participant
      *      Participant information for the account (email and password are the minimal information
-     *      required, but any portion of the information you wish to save for a participant may
+     *      required, but any portion of the information you wish to save for a participant may 
      *      be saved at sign up).
      */
     public static void signUp(String studyId, StudyParticipant participant) {
@@ -97,16 +89,16 @@ public class ClientProvider {
 
         new BaseApiCaller(null).post(config.getSignUpApi(), node);
     }
-
+    
     /**
      * Resend an email verification request to the supplied email address.
-     *
+     * 
      * @param email
      *      Email credentials associated with a Bridge account.
      */
     public static void resendEmailVerification(EmailCredentials email) {
         checkNotNull(email, "EmailCredentials required");
-
+        
         new BaseApiCaller(null).post(config.getResendEmailVerificationApi(), email);
     }
 

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/Config.java
@@ -12,7 +12,6 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Properties;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicNameValuePair;
@@ -30,6 +29,7 @@ import org.sagebionetworks.bridge.sdk.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public final class Config {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ConsentSubmission.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ConsentSubmission.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.sdk;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.joda.time.LocalDate;
+
 import org.sagebionetworks.bridge.sdk.json.DateOnlySerializer;
 import org.sagebionetworks.bridge.sdk.models.accounts.ConsentSignature;
 import org.sagebionetworks.bridge.sdk.models.accounts.SharingScope;

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/DeveloperClient.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 
-import com.google.common.net.UrlEscapers;
 import org.joda.time.DateTime;
 
 import org.sagebionetworks.bridge.sdk.models.PagedResourceList;
@@ -27,6 +26,7 @@ import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.net.UrlEscapers;
 
 public class DeveloperClient extends StudyStaffClient {
     

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/ResearcherClient.java
@@ -7,12 +7,12 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 import org.sagebionetworks.bridge.sdk.models.PagedResourceList;
 import org.sagebionetworks.bridge.sdk.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.sdk.models.holders.IdentifierHolder;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 public class ResearcherClient extends StudyStaffClient {
 

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/UserClient.java
@@ -4,17 +4,24 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.ImmutableMap;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+
 import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
+import org.sagebionetworks.bridge.sdk.models.accounts.ConsentSignature;
 import org.sagebionetworks.bridge.sdk.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.sdk.models.accounts.Withdrawal;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.schedules.Schedule;
@@ -25,18 +32,9 @@ import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSession;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadValidationStatus;
-import org.sagebionetworks.bridge.sdk.rest.api.ConsentsApi;
-import org.sagebionetworks.bridge.sdk.rest.api.ParticipantsApi;
-import org.sagebionetworks.bridge.sdk.rest.model.ConsentSignature;
-import org.sagebionetworks.bridge.sdk.rest.model.EmptyPayload;
-import org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableMap;
 
 public class UserClient extends BaseApiCaller {
     
@@ -44,12 +42,8 @@ public class UserClient extends BaseApiCaller {
     
     private final TypeReference<ResourceList<ScheduledActivity>> saType = new TypeReference<ResourceList<ScheduledActivity>>() {};
 
-    private final ParticipantsApi participantsApi;
-    private final ConsentsApi consentsApi;
     UserClient(BridgeSession session) {
         super(session);
-        this.participantsApi = API_CLIENT_PROVIDER.getClient(ParticipantsApi.class, signIn);
-        this.consentsApi = API_CLIENT_PROVIDER.getClient(ConsentsApi.class, signIn);
     }
 
     /**
@@ -58,7 +52,9 @@ public class UserClient extends BaseApiCaller {
      * @return participant - the study participant record for this user
      */
     public StudyParticipant getStudyParticipant() {
-        return call(participantsApi.getUsersParticipantRecord());
+        session.checkSignedIn();
+        
+        return get(config.getParticipantSelfApi(), StudyParticipant.class);
     }
     
     /**
@@ -90,14 +86,11 @@ public class UserClient extends BaseApiCaller {
      * @param scope
      *          Scope of sharing for this consent
      */
-    public void consentToResearch(SubpopulationGuid subpopGuid, org
-            .sagebionetworks.bridge.sdk.models.accounts.ConsentSignature signature,
-                                  SharingScope scope) {
+    public void consentToResearch(SubpopulationGuid subpopGuid, ConsentSignature signature, SharingScope scope) {
         session.checkSignedIn();
         checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
         checkNotNull(signature, CANNOT_BE_NULL, "ConsentSignature");
         checkNotNull(scope, CANNOT_BE_NULL, "SharingScope");
-
 
         ConsentSubmission submission = new ConsentSubmission(signature, scope);
         
@@ -110,14 +103,16 @@ public class UserClient extends BaseApiCaller {
      * Returns the user's consent signature, which includes the name, birthdate, and signature image.
      *
      * @param subpopGuid
-     *      the GUID object of the subpopulation which the user consented to participate in
+     *      the GUID object of the subpopulation which the user consented to participate in  
      * @return consent signature
      *      
      */
     public ConsentSignature getConsentSignature(SubpopulationGuid subpopGuid) {
+        session.checkSignedIn();
         checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-
-        return call(consentsApi.getConsentSignature(subpopGuid.getGuid()));
+        
+        ConsentSignature sig = get(config.getConsentSignatureApi(subpopGuid), ConsentSignature.class);
+        return sig;
     }
 
     /**
@@ -127,8 +122,10 @@ public class UserClient extends BaseApiCaller {
      *      email the consent to the user for the GUID object of the subpopulation the user consented to 
      */
     public void emailConsentSignature(SubpopulationGuid subpopGuid) {
+        session.checkSignedIn();
         checkNotNull(subpopGuid, CANNOT_BE_NULL, "subpopGuid");
-        call(consentsApi.emailConsentAgreement(subpopGuid.getGuid(), new EmptyPayload()));
+        
+        post(config.getEmailConsentSignatureApi(subpopGuid));
     }
 
     /**

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/WorkerClient.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/WorkerClient.java
@@ -6,15 +6,14 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.joda.time.DateTime;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.net.UrlEscapers;
-
 import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.healthData.RecordExportStatusRequest;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.sdk.models.surveys.Survey;
-import org.sagebionetworks.bridge.sdk.models.upload.Upload;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.net.UrlEscapers;
 
 /** Bridge implementation of the worker client. */
 public class WorkerClient extends BaseApiCaller {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/accounts/ConsentSignature.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/accounts/ConsentSignature.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
+
 import org.sagebionetworks.bridge.sdk.json.DateOnlySerializer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/accounts/ExternalIdentifier.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/accounts/ExternalIdentifier.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.sdk.models.accounts;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.Objects;
 

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/healthData/HealthDataRecord.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/healthData/HealthDataRecord.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.sdk.models.healthData;
 
-import org.sagebionetworks.bridge.sdk.Config;
 import java.util.Objects;
 
 /**

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/healthData/RecordExportStatusRequest.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/healthData/RecordExportStatusRequest.java
@@ -1,14 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.healthData;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.sagebionetworks.bridge.sdk.Config;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadCompletionClient;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadStatus;
-
-import java.util.List;
 
 /** Represents a record export status request to the Bridge Server. */
 public class RecordExportStatusRequest {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/reports/ReportIndex.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/reports/ReportIndex.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.sdk.models.reports;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
-import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
  * An index for a type of report, either for studies as a whole or for participants in the 

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/schedules/Schedule.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/schedules/Schedule.java
@@ -188,6 +188,7 @@ public final class Schedule {
      * @return
      */
     @JsonIgnore
+    @SuppressWarnings({"deprecation"})
     public boolean getPersistent() {
         if (activities != null) {
             for (Activity activity : activities) {

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/schedules/SchedulePlan.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/schedules/SchedulePlan.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.sdk.models.schedules;
 import java.util.Objects;
 
 import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.sdk.models.holders.GuidVersionHolder;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/subpopulations/Subpopulation.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/subpopulations/Subpopulation.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.sdk.models.subpopulations;
 
-import static org.sagebionetworks.bridge.sdk.utils.Utilities.TO_STRING_STYLE;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.sdk.utils.Utilities.TO_STRING_STYLE;
 
 import java.util.Objects;
 

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/Survey.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/Survey.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyElement.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyElement.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.sdk.models.surveys;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyQuestion.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyQuestion.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.sdk.models.holders.GuidHolder;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/Upload.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/Upload.java
@@ -9,9 +9,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
+import org.sagebionetworks.bridge.sdk.models.healthData.RecordExportStatusRequest;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.sagebionetworks.bridge.sdk.models.healthData.RecordExportStatusRequest;
 
 /**
  * A read only information object that describes the current status of an upload. This contains more

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinition.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinition.java
@@ -3,13 +3,14 @@ package org.sagebionetworks.bridge.sdk.models.upload;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+
+import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.StringUtils;
-
-import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 
 /**
  * This class represents a field definition for an upload schema. This could map to a top-level key-value pair in the

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadRequest.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadRequest.java
@@ -4,13 +4,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.io.Files;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.io.Files;
 
 /** Represents an upload request to the Bridge Server. */
 @JsonDeserialize(builder = UploadRequest.Builder.class)

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchema.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchema.java
@@ -3,15 +3,16 @@ package org.sagebionetworks.bridge.sdk.models.upload;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
-
-import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 
 /**
  * This class represents a schema for the uploads sent by the mobile apps. This can be created and updated by study

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadValidationStatus.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/models/upload/UploadValidationStatus.java
@@ -3,13 +3,14 @@ package org.sagebionetworks.bridge.sdk.models.upload;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.StringUtils;
 
 import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.sdk.models.healthData.HealthDataRecord;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 
 /** This class represents upload validation status and messages. */
 @JsonDeserialize(builder = UploadValidationStatus.Builder.class)

--- a/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/utils/Utilities.java
+++ b/java-sdk/src/main/java/org/sagebionetworks/bridge/sdk/utils/Utilities.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.commons.validator.routines.UrlValidator;
+
 import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.sdk.json.LowercaseEnumModule;
 import org.sagebionetworks.bridge.sdk.models.holders.GuidCreatedOnVersionHolder;

--- a/java-sdk/src/main/resources/bridge-sdk.properties
+++ b/java-sdk/src/main/resources/bridge-sdk.properties
@@ -1,2 +1,2 @@
 log.level = warn
-sdk.version = 4
+sdk.version = 5

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClientTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/BridgeResearcherClientTest.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.sdk;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/BridgeUserClientTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/BridgeUserClientTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.sdk;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -16,45 +16,54 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import org.sagebionetworks.bridge.Tests;
-import org.sagebionetworks.bridge.sdk.rest.model.SignIn;
-import org.sagebionetworks.bridge.sdk.rest.model.StudyParticipant;
+import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BridgeUserClientTest {
 
-    @Captor ArgumentCaptor<UserSession> sessionCaptor;
+    @Mock
+    BridgeSession session;
+    
+    @Captor
+    ArgumentCaptor<UserSession> sessionCaptor;
 
     @Test
     public void updateParticipantSelfUpdatesSession() throws Exception {
-        String json = Tests.unescapeJson("{'sessionToken':'sessionToken'," +
-                                         "'authenticated':true," +
-                                         "'languages':['en','fr']," +
-                                         "'sharingScope':'no_sharing'," +
-                                         "'firstName': 'FirstName'," +
-                                         "'lastName': 'LastName'," +
-                                         "'email': 'email@email.com'," +
-                                         "'dataGroups':['group1','group2']," +
-                                         "'id':'ABC'," +
-                                         "'consentStatuses':{'study':{'name':'Consent Name'," +
-                                         "'subpopulationGuid':'study'," +
-                                         "'required':true," +
-                                         "'consented':true," +
-                                         "'mostRecentConsent':true}}," +
-                                         "'consented':true}");
-
+        String json = Tests.unescapeJson("{'sessionToken':'sessionToken',"+
+                "'authenticated':true,"+
+                "'languages':['en','fr'],"+
+                "'sharingScope':'no_sharing',"+
+                "'firstName': 'FirstName'," +
+                "'lastName': 'LastName'," +
+                "'email': 'email@email.com'," +
+                "'dataGroups':['group1','group2'],"+
+                "'id':'ABC',"+
+                "'consentStatuses':{'study':{'name':'Consent Name',"+
+                    "'subpopulationGuid':'study',"+
+                    "'required':true,"+
+                    "'consented':true,"+
+                    "'mostRecentConsent':true}},"+
+                "'consented':true}");
+        
         UserSession session = Utilities.getMapper().readValue(json, UserSession.class);
-
-        BridgeSession bridgeSession = spy(new BridgeSession(session, new SignIn()));
+        
+        //doReturn(makeParticipant("DEF")).when(session).getStudyParticipant();
+        
+        BridgeSession bridgeSession = spy(new BridgeSession(session));
         UserClient client = new UserClient(bridgeSession);
         client = spy(client);
         doReturn(session).when(client).post(anyString(), any(StudyParticipant.class), eq(UserSession.class));
-
-        StudyParticipant participant = new StudyParticipant();
+        
+        StudyParticipant participant = makeParticipant("DEF"); // id is ignored
         client.saveStudyParticipant(participant);
-
+        
         verify(bridgeSession).setUserSession(sessionCaptor.capture());
         UserSession updatedSession = sessionCaptor.getValue();
         assertEquals("ABC", updatedSession.getStudyParticipant().getId());
+    }
+    
+    private StudyParticipant makeParticipant(String id) {
+        return new StudyParticipant.Builder().withId(id).build();
     }
 }

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/ConfigTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/ConfigTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import org.joda.time.DateTimeZone;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.sagebionetworks.bridge.sdk.Config;
 
 public class ConfigTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/EnumSerializationTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/EnumSerializationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.sagebionetworks.bridge.sdk.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/ResourceListTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/ResourceListTest.java
@@ -7,9 +7,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -17,6 +14,9 @@ import org.sagebionetworks.bridge.sdk.models.ResourceList;
 import org.sagebionetworks.bridge.sdk.models.accounts.StudyParticipant;
 
 import com.google.common.collect.Lists;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class ResourceListTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/UploadRequestTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/UploadRequestTest.java
@@ -6,11 +6,13 @@ import java.io.File;
 import java.net.URL;
 import java.util.Map;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+
 import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class UploadRequestTest {
     @Test(expected = InvalidEntityException.class)

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/UploadSessionTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/UploadSessionTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.sdk.models;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSession;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class UploadSessionTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/ConsentSignatureTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/ConsentSignatureTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.accounts;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class ConsentSignatureTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/EmailTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/EmailTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.accounts;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class EmailTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/ExternalIdentifierTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/ExternalIdentifierTest.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.sdk.models.accounts;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -10,6 +8,8 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ExternalIdentifierTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/SignInCredentialsTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/accounts/SignInCredentialsTest.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.sdk.models.accounts;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -10,6 +7,9 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class SignInCredentialsTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/healthData/HealthDataRecordTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/healthData/HealthDataRecordTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.sdk.models.healthData;
 
-import org.junit.Test;
-import org.sagebionetworks.bridge.Tests;
-import org.sagebionetworks.bridge.sdk.Config;
-import org.sagebionetworks.bridge.sdk.utils.Utilities;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.Tests;
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 public class HealthDataRecordTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/healthData/RecordExportStatusRequestTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/healthData/RecordExportStatusRequestTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.sdk.models.healthData;
 
-import org.junit.Test;
-import org.sagebionetworks.bridge.Tests;
-import org.sagebionetworks.bridge.sdk.Config;
-import org.sagebionetworks.bridge.sdk.utils.Utilities;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.sagebionetworks.bridge.Tests;
+import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 public class RecordExportStatusRequestTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidCreatedOnVersionHolderTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidCreatedOnVersionHolderTest.java
@@ -3,11 +3,11 @@ package org.sagebionetworks.bridge.sdk.models.holders;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.joda.time.DateTime;
 import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class SimpleGuidCreatedOnVersionHolderTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidHolderTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidHolderTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.holders;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SimpleGuidHolderTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidVersionHolderTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleGuidVersionHolderTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.holders;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SimpleGuidVersionHolderTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleIdentifierHolderTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleIdentifierHolderTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.holders;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SimpleIdentifierHolderTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleVersionHolderTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/holders/SimpleVersionHolderTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.holders;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SimpleVersionHolderTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ABTestScheduleStrategyTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ABTestScheduleStrategyTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.schedules;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class ABTestScheduleStrategyTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ActivityTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ActivityTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.sdk.models.schedules;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class ActivityTest {
     
@@ -23,6 +23,7 @@ public class ActivityTest {
      * @throws Exception
      */
     @Test
+    @SuppressWarnings({"deprecation"})
     public void activityKnowsWhenItIsPersistentlyScheduled() throws Exception {
         // This is persistently scheduled due to an activity
         Schedule schedule = Utilities.getMapper().readValue("{\"scheduleType\":\"once\",\"eventId\":\"activity:HHH:finished\",\"activities\":[{\"label\":\"Label\",\"labelDetail\":\"Label Detail\",\"guid\":\"HHH\",\"task\":{\"identifier\":\"foo\"},\"activityType\":\"task\"}]}", Schedule.class);

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/SchedulePlanTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/SchedulePlanTest.java
@@ -2,12 +2,13 @@ package org.sagebionetworks.bridge.sdk.models.schedules;
 
 import static org.junit.Assert.assertEquals;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.junit.Test;
+
 import org.sagebionetworks.bridge.Tests;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class SchedulePlanTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ScheduleTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ScheduleTest.java
@@ -2,8 +2,6 @@ package org.sagebionetworks.bridge.sdk.models.schedules;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
@@ -13,6 +11,9 @@ import org.junit.Test;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.google.common.collect.Lists;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class ScheduleTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ScheduledActivityTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/ScheduledActivityTest.java
@@ -4,13 +4,13 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.joda.time.DateTime;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class ScheduledActivityTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/SurveyReferenceTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/SurveyReferenceTest.java
@@ -2,11 +2,12 @@ package org.sagebionetworks.bridge.sdk.models.schedules;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class SurveyReferenceTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/TaskReferenceTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/schedules/TaskReferenceTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.schedules;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class TaskReferenceTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/studies/EmailTemplateTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/studies/EmailTemplateTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.sdk.models.studies;
 
 import static org.junit.Assert.assertEquals;
-import nl.jqno.equalsverifier.EqualsVerifier;
 
 import org.junit.Test;
 
@@ -9,6 +8,8 @@ import org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate.MimeType;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class EmailTemplateTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/studies/PasswordPolicyTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/studies/PasswordPolicyTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.sdk.models.studies;
 
 import static org.junit.Assert.assertEquals;
-import nl.jqno.equalsverifier.EqualsVerifier;
 
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class PasswordPolicyTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/studies/StudyTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/studies/StudyTest.java
@@ -3,15 +3,15 @@ package org.sagebionetworks.bridge.sdk.models.studies;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.models.studies.EmailTemplate.MimeType;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class StudyTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/subpopulations/StudyConsentTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/subpopulations/StudyConsentTest.java
@@ -1,11 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.subpopulations;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-
 import org.junit.Test;
 
-import org.sagebionetworks.bridge.sdk.models.subpopulations.StudyConsent;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class StudyConsentTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/subpopulations/SubpopulationTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/subpopulations/SubpopulationTest.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.bridge.Tests;
 import org.sagebionetworks.bridge.sdk.models.Criteria;
 import org.sagebionetworks.bridge.sdk.models.studies.OperatingSystem;
 import org.sagebionetworks.bridge.sdk.models.studies.Study;
-import org.sagebionetworks.bridge.sdk.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
 
 import com.google.common.collect.Sets;

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/ConstraintsTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/ConstraintsTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.surveys;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class ConstraintsTest {
 

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyAnswerTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyAnswerTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.surveys;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SurveyAnswerTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyInfoScreenTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyInfoScreenTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.surveys;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SurveyInfoScreenTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyQuestionTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyQuestionTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.surveys;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SurveyQuestionTest {
     

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/surveys/SurveyTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.sdk.models.surveys;
 
+import org.junit.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class SurveyTest {
     @Test

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinitionTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadFieldDefinitionTest.java
@@ -8,12 +8,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.google.common.collect.ImmutableList;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class UploadFieldDefinitionTest {
     @Test(expected = InvalidEntityException.class)

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadSchemaTest.java
@@ -7,13 +7,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.google.common.collect.ImmutableList;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 @SuppressWarnings("unchecked")
 public class UploadSchemaTest {

--- a/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadValidationStatusTest.java
+++ b/java-sdk/src/test/java/org/sagebionetworks/bridge/sdk/models/upload/UploadValidationStatusTest.java
@@ -7,12 +7,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import org.sagebionetworks.bridge.sdk.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.sdk.utils.Utilities;
+
+import com.google.common.collect.ImmutableList;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 @SuppressWarnings("unchecked")
 public class UploadValidationStatusTest {

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/sdk/rest/ErrorResponseInterceptor.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/sdk/rest/ErrorResponseInterceptor.java
@@ -6,9 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.sagebionetworks.bridge.sdk.rest.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.sdk.rest.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.sdk.rest.exceptions.ConcurrentModificationException;

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/sdk/rest/LoggingInterceptor.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/sdk/rest/LoggingInterceptor.java
@@ -24,7 +24,8 @@ public class LoggingInterceptor implements Interceptor {
         Request request = chain.request();
         if (logger.isDebugEnabled()) {
             if ("POST".equals(request.method()) || "PUT".equals(request.method())) {
-                logger.debug(request.method()+" "+request.url().toString()+"\n    "+requestBodyToString(request));    
+                logger.debug(request.method() + " " + request.url().toString() + "\n    "
+                        + redactPasswords(requestBodyToString(request)));
             } else {
                 logger.debug(request.method()+" "+request.url().toString());
             }
@@ -37,16 +38,20 @@ public class LoggingInterceptor implements Interceptor {
             Response newResponse = response.newBuilder()
                     .body(ResponseBody.create(body.contentType(), bodyString.getBytes())).build();
 
-            logger.debug("    "+response.code()+": "+bodyString);
+            logger.debug(response.code()+" RESPONSE: "+redactPasswords(bodyString));
             return newResponse;
         }
         return response;
     }
 
-    private static String requestBodyToString(final Request request) throws IOException {
+    private String requestBodyToString(final Request request) throws IOException {
         Request copy = request.newBuilder().build();
         Buffer buffer = new Buffer();
         copy.body().writeTo(buffer);
         return buffer.readUtf8();
+    }
+    
+    private String redactPasswords(String string) {
+        return string.replaceAll("password\":\"([^\"]*)\"", "password\":\"[REDACTED]\"");
     }
 }


### PR DESCRIPTION
Keeping these two variants of the SDK files separate, to migrate integration tests one file at a time.
