### PR TITLE
Some formatting and documentation changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.5</version>
+    <version>0.12.6</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.4</version>
+    <version>0.12.5</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.5</version>
+        <version>0.12.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.4</version>
+        <version>0.12.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
@@ -29,7 +29,6 @@ import org.sagebionetworks.bridge.rest.model.DateConstraints;
 import org.sagebionetworks.bridge.rest.model.DateTimeConstraints;
 import org.sagebionetworks.bridge.rest.model.DecimalConstraints;
 import org.sagebionetworks.bridge.rest.model.DurationConstraints;
-import org.sagebionetworks.bridge.rest.model.EmptyPayload;
 import org.sagebionetworks.bridge.rest.model.IntegerConstraints;
 import org.sagebionetworks.bridge.rest.model.MultiValueConstraints;
 import org.sagebionetworks.bridge.rest.model.ScheduleStrategy;
@@ -147,8 +146,21 @@ public class RestUtils {
     }
     
     /**
-     * Convert ClientInfo object into a User-Agent header value that can be used by the Bridge 
-     * server to filter content appropriately for your app.
+     * <p>Convert ClientInfo object into a User-Agent header value that can be used by the Bridge 
+     * server to filter content appropriately for your app.</p>
+     * 
+     * <p>There are three main stanzas in the Bridge User-Agent header, and all parts of a given 
+     * stanza must be provided or that stanza will be dropped from the final header:</p>
+     * 
+     *  <ul>
+     *   <li>appName and appVersion;</li>
+     *   <li>deviceName, osName and osVersion;</li>
+     *   <li>sdkName and sdkVersion</li>
+     *  </ul>
+     *  
+     *  <p>The ClientManager will provide values for the final two groupings (and enforces 
+     *  settings for the SDK information). </p>
+     * 
      * @param info
      *      a ClientInfo object
      * @return
@@ -215,7 +227,7 @@ public class RestUtils {
         RequestBody body = RequestBody.create(MediaType.parse(request.getContentType()), file);
 
         s3service.uploadToS3(session.getUrl(), body, request.getContentMd5(), request.getContentType()).execute();
-        usersApi.completeUploadSession(session.getId(), new EmptyPayload()).execute();
+        usersApi.completeUploadSession(session.getId()).execute();
         
         return session;
     }    

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactory.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactory.java
@@ -36,32 +36,39 @@ import com.google.gson.stream.JsonWriter;
 // where this file was copied from.
 
 /**
- * Adapts values whose runtime type may differ from their declaration type. This
- * is necessary when a field's type is not the same type that GSON should create
- * when deserializing that field. For example, consider these types:
- * <pre>   {@code
- *   abstract class Shape {
- *     int x;
- *     int y;
- *   }
- *   class Circle extends Shape {
- *     int radius;
- *   }
- *   class Rectangle extends Shape {
- *     int width;
- *     int height;
- *   }
- *   class Diamond extends Shape {
- *     int width;
- *     int height;
- *   }
- *   class Drawing {
- *     Shape bottomShape;
- *     Shape topShape;
- *   }
- * }</pre>
- * <p>Without additional type information, the serialized JSON is ambiguous. Is
- * the bottom shape in this drawing a rectangle or a diamond? <pre>   {@code
+ * Adapts values whose runtime type may differ from their declaration type. This is necessary when a field's type is not
+ * the same type that GSON should create when deserializing that field. For example, consider these types:
+ * 
+ * <pre>
+ * {
+ *     &#64;code
+ *     abstract class Shape {
+ *         int x;
+ *         int y;
+ *     }
+ *     class Circle extends Shape {
+ *         int radius;
+ *     }
+ *     class Rectangle extends Shape {
+ *         int width;
+ *         int height;
+ *     }
+ *     class Diamond extends Shape {
+ *         int width;
+ *         int height;
+ *     }
+ *     class Drawing {
+ *         Shape bottomShape;
+ *         Shape topShape;
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * Without additional type information, the serialized JSON is ambiguous. Is the bottom shape in this drawing a
+ * rectangle or a diamond?
+ * 
+ * <pre>
+ *    {@code
  *   {
  *     "bottomShape": {
  *       "width": 10,
@@ -74,10 +81,14 @@ import com.google.gson.stream.JsonWriter;
  *       "x": 4,
  *       "y": 1
  *     }
- *   }}</pre>
- * This class addresses this problem by adding type information to the
- * serialized JSON and honoring that type information when the JSON is
- * deserialized: <pre>   {@code
+ *   }}
+ * </pre>
+ * 
+ * This class addresses this problem by adding type information to the serialized JSON and honoring that type
+ * information when the JSON is deserialized:
+ * 
+ * <pre>
+ *    {@code
  *   {
  *     "bottomShape": {
  *       "type": "Diamond",
@@ -92,157 +103,164 @@ import com.google.gson.stream.JsonWriter;
  *       "x": 4,
  *       "y": 1
  *     }
- *   }}</pre>
+ *   }}
+ * </pre>
+ * 
  * Both the type field name ({@code "type"}) and the type labels ({@code
  * "Rectangle"}) are configurable.
  *
- * <h3>Registering Types</h3>
- * Create a {@code RuntimeTypeAdapterFactory} by passing the base type and type field
- * name to the {@link #of} factory method. If you don't supply an explicit type
- * field name, {@code "type"} will be used. <pre>   {@code
- *   RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory
- *       = RuntimeTypeAdapterFactory.of(Shape.class, "type");
- * }</pre>
- * Next register all of your subtypes. Every subtype must be explicitly
- * registered. This protects your application from injection attacks. If you
- * don't supply an explicit type label, the type's simple name will be used.
- * <pre>   {@code
+ * <h3>Registering Types</h3> Create a {@code RuntimeTypeAdapterFactory} by passing the base type and type field name to
+ * the {@link #of} factory method. If you don't supply an explicit type field name, {@code "type"} will be used.
+ * 
+ * <pre>
+ * {
+ *     &#64;code
+ *     RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory = RuntimeTypeAdapterFactory.of(Shape.class, "type");
+ * }
+ * </pre>
+ * 
+ * Next register all of your subtypes. Every subtype must be explicitly registered. This protects your application from
+ * injection attacks. If you don't supply an explicit type label, the type's simple name will be used.
+ * 
+ * <pre>
+ *    {@code
  *   shapeAdapter.registerSubtype(Rectangle.class, "Rectangle");
  *   shapeAdapter.registerSubtype(Circle.class, "Circle");
  *   shapeAdapter.registerSubtype(Diamond.class, "Diamond");
- * }</pre>
+ * }
+ * </pre>
+ * 
  * Finally, register the type adapter factory in your application's GSON builder:
- * <pre>   {@code
- *   Gson gson = new GsonBuilder()
- *       .registerTypeAdapterFactory(shapeAdapterFactory)
- *       .create();
- * }</pre>
- * Like {@code GsonBuilder}, this API supports chaining: <pre>   {@code
- *   RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory = RuntimeTypeAdapterFactory.of(Shape.class)
- *       .registerSubtype(Rectangle.class)
- *       .registerSubtype(Circle.class)
- *       .registerSubtype(Diamond.class);
- * }</pre>
+ * 
+ * <pre>
+ * {
+ *     &#64;code
+ *     Gson gson = new GsonBuilder().registerTypeAdapterFactory(shapeAdapterFactory).create();
+ * }
+ * </pre>
+ * 
+ * Like {@code GsonBuilder}, this API supports chaining:
+ * 
+ * <pre>
+ * {
+ *     &#64;code
+ *     RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory = RuntimeTypeAdapterFactory.of(Shape.class)
+ *             .registerSubtype(Rectangle.class).registerSubtype(Circle.class).registerSubtype(Diamond.class);
+ * }
+ * </pre>
  */
 public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
-  private final Class<?> baseType;
-  private final String typeFieldName;
-  private final Map<String, Class<?>> labelToSubtype = new LinkedHashMap<String, Class<?>>();
-  private final Map<Class<?>, String> subtypeToLabel = new LinkedHashMap<Class<?>, String>();
+    private final Class<?> baseType;
+    private final String typeFieldName;
+    private final Map<String, Class<?>> labelToSubtype = new LinkedHashMap<String, Class<?>>();
+    private final Map<Class<?>, String> subtypeToLabel = new LinkedHashMap<Class<?>, String>();
 
-  private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName) {
-    if (typeFieldName == null || baseType == null) {
-      throw new NullPointerException();
-    }
-    this.baseType = baseType;
-    this.typeFieldName = typeFieldName;
-  }
-
-  /**
-   * Creates a new runtime type adapter using for {@code baseType} using {@code
-   * typeFieldName} as the type field name. Type field names are case sensitive.
-   */
-  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, typeFieldName);
-  }
-
-  /**
-   * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as
-   * the type field name.
-   */
-  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, "type");
-  }
-
-  /**
-   * Registers {@code type} identified by {@code label}. Labels are case
-   * sensitive.
-   *
-   * @throws IllegalArgumentException if either {@code type} or {@code label}
-   *     have already been registered on this type adapter.
-   */
-  public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
-    if (type == null || label == null) {
-      throw new NullPointerException();
-    }
-    if (subtypeToLabel.containsKey(type) || labelToSubtype.containsKey(label)) {
-      throw new IllegalArgumentException("types and labels must be unique");
-    }
-    labelToSubtype.put(label, type);
-    subtypeToLabel.put(type, label);
-    return this;
-  }
-
-  /**
-   * Registers {@code type} identified by its {@link Class#getSimpleName simple
-   * name}. Labels are case sensitive.
-   *
-   * @throws IllegalArgumentException if either {@code type} or its simple name
-   *     have already been registered on this type adapter.
-   */
-  public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
-    return registerSubtype(type, type.getSimpleName());
-  }
-
-  public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-    if (type.getRawType() != baseType) {
-      return null;
+    private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName) {
+        if (typeFieldName == null || baseType == null) {
+            throw new NullPointerException();
+        }
+        this.baseType = baseType;
+        this.typeFieldName = typeFieldName;
     }
 
-    final Map<String, TypeAdapter<?>> labelToDelegate
-        = new LinkedHashMap<String, TypeAdapter<?>>();
-    final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate
-        = new LinkedHashMap<Class<?>, TypeAdapter<?>>();
-    for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
-      TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
-      labelToDelegate.put(entry.getKey(), delegate);
-      subtypeToDelegate.put(entry.getValue(), delegate);
+    /**
+     * Creates a new runtime type adapter using for {@code baseType} using {@code
+     * typeFieldName} as the type field name. Type field names are case sensitive.
+     */
+    public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
+        return new RuntimeTypeAdapterFactory<T>(baseType, typeFieldName);
     }
 
-    return new TypeAdapter<R>() {
-      @Override public R read(JsonReader in) throws IOException {
-        JsonElement jsonElement = Streams.parse(in);
-        // This originally removed the element, but we don't want that, we want to preserve it.
-        // There are places in Surveys where the server is looking for the "type" property to deserialize.
-        JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
-        if (labelJsonElement == null) {
-          throw new JsonParseException("cannot deserialize " + baseType
-              + " because it does not define a field named " + typeFieldName);
-        }
-        String label = labelJsonElement.getAsString();
-        @SuppressWarnings("unchecked") // registration requires that subtype extends T
-        TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
-        if (delegate == null) {
-          throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
-              + label + "; did you forget to register a subtype?");
-        }
-        return delegate.fromJsonTree(jsonElement);
-      }
+    /**
+     * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as the type field name.
+     */
+    public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
+        return new RuntimeTypeAdapterFactory<T>(baseType, "type");
+    }
 
-      @Override public void write(JsonWriter out, R value) throws IOException {
-        Class<?> srcType = value.getClass();
-        String label = subtypeToLabel.get(srcType);
-        @SuppressWarnings("unchecked") // registration requires that subtype extends T
-        TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
-        if (delegate == null) {
-          throw new JsonParseException("cannot serialize " + srcType.getName()
-              + "; did you forget to register a subtype?");
+    /**
+     * Registers {@code type} identified by {@code label}. Labels are case sensitive.
+     *
+     * @throws IllegalArgumentException
+     *             if either {@code type} or {@code label} have already been registered on this type adapter.
+     */
+    public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
+        if (type == null || label == null) {
+            throw new NullPointerException();
         }
-        JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
-        /* Yes, this field exists... that's fine. We had to define it in the Swagger file so it
-         * is specified. 
-        if (jsonObject.has(typeFieldName)) {
-          throw new JsonParseException("cannot serialize " + srcType.getName()
-              + " because it already defines a field named " + typeFieldName);
+        if (subtypeToLabel.containsKey(type) || labelToSubtype.containsKey(label)) {
+            throw new IllegalArgumentException("types and labels must be unique");
         }
-        */
-        JsonObject clone = new JsonObject();
-        clone.add(typeFieldName, new JsonPrimitive(label));
-        for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
-          clone.add(e.getKey(), e.getValue());
+        labelToSubtype.put(label, type);
+        subtypeToLabel.put(type, label);
+        return this;
+    }
+
+    /**
+     * Registers {@code type} identified by its {@link Class#getSimpleName simple name}. Labels are case sensitive.
+     *
+     * @throws IllegalArgumentException
+     *             if either {@code type} or its simple name have already been registered on this type adapter.
+     */
+    public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
+        return registerSubtype(type, type.getSimpleName());
+    }
+
+    public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+        if (type.getRawType() != baseType) {
+            return null;
         }
-        Streams.write(clone, out);
-      }
-    }.nullSafe();
-  }
+
+        final Map<String, TypeAdapter<?>> labelToDelegate = new LinkedHashMap<String, TypeAdapter<?>>();
+        final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate = new LinkedHashMap<Class<?>, TypeAdapter<?>>();
+        for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
+            TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
+            labelToDelegate.put(entry.getKey(), delegate);
+            subtypeToDelegate.put(entry.getValue(), delegate);
+        }
+
+        return new TypeAdapter<R>() {
+            @Override
+            public R read(JsonReader in) throws IOException {
+                JsonElement jsonElement = Streams.parse(in);
+                // This originally removed the element, but we don't want that, we want to preserve it.
+                // There are places in Surveys where the server is looking for the "type" property to deserialize.
+                JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
+                if (labelJsonElement == null) {
+                    throw new JsonParseException("cannot deserialize " + baseType
+                            + " because it does not define a field named " + typeFieldName);
+                }
+                String label = labelJsonElement.getAsString();
+                @SuppressWarnings("unchecked") // registration requires that subtype extends T
+                TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
+                if (delegate == null) {
+                    throw new JsonParseException("cannot deserialize " + baseType + " subtype named " + label
+                            + "; did you forget to register a subtype?");
+                }
+                return delegate.fromJsonTree(jsonElement);
+            }
+
+            @Override
+            public void write(JsonWriter out, R value) throws IOException {
+                Class<?> srcType = value.getClass();
+                String label = subtypeToLabel.get(srcType);
+                @SuppressWarnings("unchecked") // registration requires that subtype extends T
+                TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
+                if (delegate == null) {
+                    throw new JsonParseException(
+                            "cannot serialize " + srcType.getName() + "; did you forget to register a subtype?");
+                }
+                JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
+                JsonObject clone = new JsonObject();
+                for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
+                    if (e.getValue() != null) {
+                        clone.add(e.getKey(), e.getValue());
+                    }
+
+                }
+                clone.add(typeFieldName, new JsonPrimitive(label));
+                Streams.write(clone, out);
+            }
+        }.nullSafe();
+    }
 }

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactory.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactory.java
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 
+ * Taken from:
+ * https://github.com/google/gson/blob/master/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
  */
 
 package org.sagebionetworks.bridge.rest.gson;
@@ -31,9 +34,6 @@ import com.google.gson.internal.Streams;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-
-// NOTE: I do not see a maven repository that includes the gson extras package, 
-// where this file was copied from.
 
 /**
  * Adapts values whose runtime type may differ from their declaration type. This is necessary when a field's type is not

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactoryTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactoryTest.java
@@ -1,0 +1,62 @@
+package org.sagebionetworks.bridge.rest.gson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+import java.io.Writer;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.sagebionetworks.bridge.rest.model.SurveyElement;
+import org.sagebionetworks.bridge.rest.model.SurveyInfoScreen;
+import org.sagebionetworks.bridge.rest.model.SurveyQuestion;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonWriter;
+
+@RunWith(PowerMockRunner.class)
+public class RuntimeTypeAdapterFactoryTest {
+    private static final RuntimeTypeAdapterFactory<SurveyElement> FACTORY = RuntimeTypeAdapterFactory  
+            .of(SurveyElement.class, "type")
+            .registerSubtype(SurveyQuestion.class, SurveyQuestion.class.getSimpleName())
+            .registerSubtype(SurveyInfoScreen.class, SurveyInfoScreen.class.getSimpleName());
+
+    @Test
+    @Ignore
+    public void testSuperType() throws Exception {
+        TypeAdapter<SurveyElement> typeAdapter = FACTORY.create(new GsonBuilder().create(), new TypeToken<SurveyElement>() {});
+
+        SurveyElement element = new SurveyElement();
+        element.setGuid("GUID");
+        
+        Writer outputWriter = new StringWriter();
+        JsonWriter writer = new JsonWriter(outputWriter);
+        
+        typeAdapter.write(writer, element);
+        
+        assertTrue(outputWriter.toString().contains("\"type\":\"SurveyElement\""));
+    }
+    
+    @Test
+    public void testSubType() throws Exception {
+        TypeAdapter<SurveyElement> typeAdapter = FACTORY.create(new GsonBuilder().create(), new TypeToken<SurveyElement>() {});
+
+        SurveyQuestion question = new SurveyQuestion();
+        question.setTitle("This is a title");
+        
+        Writer outputWriter = new StringWriter();
+        JsonWriter writer = new JsonWriter(outputWriter);
+        
+        typeAdapter.write(writer, question);
+        System.out.println(outputWriter.toString());
+        
+        assertTrue(outputWriter.toString().contains("\"type\":\"SurveyQuestion\""));
+    }
+}

--- a/rest-client/swagger.json
+++ b/rest-client/swagger.json
@@ -138,15 +138,6 @@
       "type": "string",
       "format": "date-time",
       "required": true
-    },
-    "empty": {
-      "name": "body",
-      "description": "Bridge currently requires an empty JSON object for POSTs without body content",
-      "required": true,
-      "in": "body",
-      "schema": {
-        "$ref": "#/definitions/EmptyPayload"
-      }
     }
   },
   "paths": {
@@ -208,11 +199,6 @@
           }
         ],
         "description": "Delete the user's session on the server.\n",
-        "parameters": [
-          {
-            "$ref": "#/parameters/empty"
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/200_message"
@@ -854,9 +840,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/userId"
-          },
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -1555,9 +1538,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/subpopulationGuid"
-          },
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -1939,9 +1919,6 @@
             "format": "date-time",
             "in": "path",
             "required": true
-          },
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -2045,13 +2022,10 @@
         ],
         "parameters": [
           {
-            "name": "DateRange",
-            "in": "body",
-            "description": "Date range",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/DateRange"
-            }
+            "$ref": "#/parameters/startDate"
+          },
+          {
+            "$ref": "#/parameters/endDate"
           }
         ],
         "responses": {
@@ -2644,9 +2618,6 @@
           },
           {
             "$ref": "#/parameters/createdOn"
-          },
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -2687,9 +2658,6 @@
           },
           {
             "$ref": "#/parameters/newSchemaRev"
-          },
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -2802,9 +2770,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/uploadId"
-          },
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -3370,13 +3335,10 @@
         ],
         "parameters": [
           {
-            "name": "format",
+            "name": "summary",
             "required": false,
             "in": "query",
-            "type": "string",
-            "enum": [
-              "summary"
-            ],
+            "type": "boolean",
             "description": "If true, anyone can call this endpoint and return a list of truncated study objects\n(name and study identifier only). Otherwise, caller must be an admin.\n"
           }
         ],
@@ -3660,11 +3622,6 @@
         "security": [
           {
             "BridgeSecurity": []
-          }
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/empty"
           }
         ],
         "responses": {
@@ -4041,9 +3998,7 @@
                 "type": {
                   "type": "string",
                   "readOnly": true,
-                  "enum": [
-                    "ResourceList"
-                  ]
+                  "description": "ResourceList"
                 }
               }
             }
@@ -4356,9 +4311,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ABTestGroup"
-          ]
+          "description": "ABTestGroup"
         }
       }
     },
@@ -4489,9 +4442,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "AccountSummary"
-          ]
+          "description": "AccountSummary"
         }
       }
     },
@@ -4527,9 +4478,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Activity"
-          ]
+          "description": "Activity"
         }
       }
     },
@@ -4569,9 +4518,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ClientInfo"
-          ]
+          "description": "ClientInfo"
         }
       }
     },
@@ -4590,9 +4537,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "CmsPublicKey"
-          ]
+          "description": "CmsPublicKey"
         }
       }
     },
@@ -4643,9 +4588,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ConsentSignature"
-          ]
+          "description": "ConsentSignature"
         }
       }
     },
@@ -4677,9 +4620,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ConsentStatus"
-          ]
+          "description": "ConsentStatus"
         }
       }
     },
@@ -4722,9 +4663,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Criteria"
-          ]
+          "description": "Criteria"
         }
       }
     },
@@ -4771,35 +4710,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "DataGroups"
-          ]
-        }
-      }
-    },
-    "DateRange": {
-      "type": "object",
-      "required": [
-        "startDate",
-        "endDate"
-      ],
-      "properties": {
-        "startDate": {
-          "type": "string",
-          "format": "date",
-          "description": "Start date of the date range."
-        },
-        "endDate": {
-          "type": "string",
-          "format": "date",
-          "description": "End date of the date range."
-        },
-        "type": {
-          "type": "string",
-          "readOnly": true,
-          "enum": [
-            "DateRange"
-          ]
+          "description": "DataGroups"
         }
       }
     },
@@ -4822,9 +4733,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Email"
-          ]
+          "description": "Email"
         }
       }
     },
@@ -4851,9 +4760,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "EmailTemplate"
-          ]
+          "description": "EmailTemplate"
         }
       }
     },
@@ -4871,9 +4778,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "EmailVerification"
-          ]
+          "description": "EmailVerification"
         }
       }
     },
@@ -4890,14 +4795,9 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "EmailVerificationStatus"
-          ]
+          "description": "EmailVerificationStatus"
         }
       }
-    },
-    "EmptyPayload": {
-      "type": "object"
     },
     "ExternalIdentifier": {
       "description": "An external identifier assigned to a participant's account to allow external \nre-identification of the user by the study sponsor.\n",
@@ -4918,9 +4818,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ExternalIdentifier"
-          ]
+          "description": "ExternalIdentifier"
         }
       }
     },
@@ -4948,9 +4846,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "GuidCreatedOnVersionHolder"
-          ]
+          "description": "GuidCreatedOnVersionHolder"
         }
       }
     },
@@ -4972,9 +4868,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "GuidVersionHolder"
-          ]
+          "description": "GuidVersionHolder"
         }
       }
     },
@@ -5054,9 +4948,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "HealthDataRecord"
-          ]
+          "description": "HealthDataRecord"
         }
       }
     },
@@ -5072,9 +4964,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "IdentifierHolder"
-          ]
+          "description": "IdentifierHolder"
         }
       }
     },
@@ -5099,9 +4989,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Image"
-          ]
+          "description": "Image"
         }
       }
     },
@@ -5172,9 +5060,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "PasswordPolicy"
-          ]
+          "description": "PasswordPolicy"
         }
       }
     },
@@ -5198,9 +5084,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "PasswordReset"
-          ]
+          "description": "PasswordReset"
         }
       }
     },
@@ -5225,9 +5109,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "RecordExportStatusRequest"
-          ]
+          "description": "RecordExportStatusRequest"
         }
       }
     },
@@ -5255,9 +5137,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ReportData"
-          ]
+          "description": "ReportData"
         }
       }
     },
@@ -5275,9 +5155,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ReportIndex"
-          ]
+          "description": "ReportIndex"
         }
       }
     },
@@ -5336,9 +5214,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ClientInfo"
-          ]
+          "description": "ClientInfo"
         }
       }
     },
@@ -5412,9 +5288,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Schedule"
-          ]
+          "description": "Schedule"
         }
       }
     },
@@ -5435,9 +5309,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ScheduleCriteria"
-          ]
+          "description": "ScheduleCriteria"
         }
       }
     },
@@ -5472,9 +5344,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "SchedulePlan"
-          ]
+          "description": "SchedulePlan"
         }
       }
     },
@@ -5540,9 +5410,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ScheduledActivity"
-          ]
+          "description": "ScheduledActivity"
         }
       }
     },
@@ -5558,9 +5426,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "SharingScope"
-          ]
+          "description": "SharingScope"
         }
       }
     },
@@ -5589,9 +5455,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "SignIn"
-          ]
+          "description": "SignIn"
         }
       }
     },
@@ -5633,9 +5497,7 @@
             "type": {
               "type": "string",
               "readOnly": true,
-              "enum": [
-                "SignUp"
-              ]
+              "description": "SignUp"
             }
           }
         }
@@ -5789,9 +5651,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Study"
-          ]
+          "description": "Study"
         }
       }
     },
@@ -5820,9 +5680,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "StudyConsent"
-          ]
+          "description": "StudyConsent"
         }
       }
     },
@@ -5840,9 +5698,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "StudyIdentifier"
-          ]
+          "description": "StudyIdentifier"
         }
       }
     },
@@ -5879,9 +5735,7 @@
             "type": {
               "type": "string",
               "readOnly": true,
-              "enum": [
-                "StudyParticipant"
-              ]
+              "description": "StudyParticipant"
             }
           }
         }
@@ -5944,9 +5798,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Subpopulation"
-          ]
+          "description": "Subpopulation"
         }
       }
     },
@@ -6009,9 +5861,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Survey"
-          ]
+          "description": "Survey"
         }
       }
     },
@@ -6142,9 +5992,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "SurveyQuestionOption"
-          ]
+          "description": "SurveyQuestionOption"
         }
       }
     },
@@ -6176,9 +6024,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "SurveyReference"
-          ]
+          "description": "SurveyReference"
         }
       }
     },
@@ -6208,9 +6054,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "SurveyRule"
-          ]
+          "description": "SurveyRule"
         }
       }
     },
@@ -6228,9 +6072,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "TaskReference"
-          ]
+          "description": "TaskReference"
         }
       }
     },
@@ -6296,9 +6138,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Upload"
-          ]
+          "description": "Upload"
         }
       }
     },
@@ -6381,9 +6221,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "UploadRequest"
-          ]
+          "description": "UploadRequest"
         }
       }
     },
@@ -6441,9 +6279,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "UploadSchema"
-          ]
+          "description": "UploadSchema"
         }
       }
     },
@@ -6471,9 +6307,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "UploadSession"
-          ]
+          "description": "UploadSession"
         }
       }
     },
@@ -6501,9 +6335,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "UploadValidationStatus"
-          ]
+          "description": "UploadValidationStatus"
         }
       }
     },
@@ -6556,9 +6388,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "UserConsentHistory"
-          ]
+          "description": "UserConsentHistory"
         }
       }
     },
@@ -6586,9 +6416,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "UserProfile"
-          ]
+          "description": "UserProfile"
         }
       }
     },
@@ -6642,9 +6470,7 @@
             "type": {
               "type": "string",
               "readOnly": true,
-              "enum": [
-                "UserSessionInfo"
-              ]
+              "description": "UserSessionInfo"
             }
           }
         }
@@ -6663,9 +6489,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "VersionHolder"
-          ]
+          "description": "VersionHolder"
         }
       }
     },
@@ -6679,9 +6503,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "Withdrawal"
-          ]
+          "description": "Withdrawal"
         }
       }
     },
@@ -6715,9 +6537,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "PagedResourceList"
-          ]
+          "description": "PagedResourceList"
         }
       }
     },
@@ -6746,9 +6566,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6780,9 +6598,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "PagedResourceList"
-          ]
+          "description": "PagedResourceList"
         }
       }
     },
@@ -6810,9 +6626,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "DateRangeResourceList"
-          ]
+          "description": "DateRangeResourceList"
         }
       }
     },
@@ -6835,9 +6649,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ReportTypeResourceList"
-          ]
+          "description": "ReportTypeResourceList"
         }
       }
     },
@@ -6858,9 +6670,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6881,9 +6691,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6904,9 +6712,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6927,9 +6733,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6950,9 +6754,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6973,9 +6775,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -6996,9 +6796,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -7029,9 +6827,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "DateTimeRangeResourceList"
-          ]
+          "description": "DateTimeRangeResourceList"
         }
       }
     },
@@ -7052,9 +6848,7 @@
         "type": {
           "type": "string",
           "readOnly": true,
-          "enum": [
-            "ResourceList"
-          ]
+          "description": "ResourceList"
         }
       }
     },
@@ -7076,7 +6870,8 @@
           "$ref": "#/definitions/DataType"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         }
       }
     },


### PR DESCRIPTION
Removing EmptyPayload (no longer in any API client signature);

Fixing RuntimeTypeAdapterFactory so that types the server needs are added to the JSON sent through the GSON serializer. This means you do not need to call setType() on anything when creating objects with the REST client to send to the Bridge server.