### PR TITLE
increase timeouts to fix Devo integ tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.4</version>
+    <version>0.12.5</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.4</version>
+        <version>0.12.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ApiClientProvider.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ApiClientProvider.java
@@ -36,12 +36,12 @@ public class ApiClientProvider {
         
         UserSessionInterceptor sessionInterceptor = new UserSessionInterceptor();
 
-        // 5 second timeout: creating studies takes awhile, and tests fail if the timeout is shorter.
+        // Devo may take up to 2 minutes to boot up. Need to set timeouts accordingly so that integration tests succeed
         // May want to make it possible to configure this value when creating the ApiClientProvider.
         unauthenticatedOkHttpClient = new OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS) // server times out after 30 seconds, past this it's pointless to wait.
-                .readTimeout(30, TimeUnit.SECONDS)
-                .writeTimeout(30, TimeUnit.SECONDS)
+                .connectTimeout(2, TimeUnit.MINUTES)
+                .readTimeout(2, TimeUnit.MINUTES)
+                .writeTimeout(2, TimeUnit.MINUTES)
                 .addInterceptor(sessionInterceptor)
                 .addInterceptor(new HeaderInterceptor(userAgent))
                 .addInterceptor(new DeprecationInterceptor())


### PR DESCRIPTION
Devo takes up to 2 minutes to boot, so set the timeouts accordingly.

Testing done:
* Pulled this into integ tests, ran a single test to verify this works.