### PR TITLE
You can set all the fields of ClientInfo from your bridge-sdk.properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.7</version>
+    <version>0.12.8</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.7</version>
+        <version>0.12.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ClientManager.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ClientManager.java
@@ -220,7 +220,9 @@ public final class ClientManager {
             }
             if (this.acceptLanguages == null || this.acceptLanguages.isEmpty()) {
                 String langs = this.config.getLanguages();
-                this.acceptLanguages = SPLITTER.splitToList(langs);
+                if (!isNullOrEmpty(langs)) {
+                    this.acceptLanguages = SPLITTER.splitToList(langs);    
+                }
             }
             ClientInfo info = getDefaultClientInfo();
             if (this.clientInfo != null) {

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
@@ -21,10 +21,15 @@ public final class Config {
         ACCOUNT_PASSWORD, 
         ADMIN_EMAIL, 
         ADMIN_PASSWORD, 
-        DEV_NAME, 
+        APP_NAME,
+        APP_VERSION,
+        DEV_NAME,
+        DEVICE_NAME,
         ENV, 
         LANGUAGES,
         LOG_LEVEL, 
+        OS_NAME,
+        OS_VERSION,
         SDK_VERSION, 
         STUDY_IDENTIFIER;
 
@@ -140,6 +145,26 @@ public final class Config {
     public String getDevName() {
         return fromProperty(Props.DEV_NAME);
     }
+    
+    public String getAppName() {
+        return fromProperty(Props.APP_NAME);
+    }
+    
+    public String getAppVersion() {
+        return fromProperty(Props.APP_VERSION);
+    }
+    
+    public String getDeviceName() {
+        return fromProperty(Props.DEVICE_NAME);
+    }
+    
+    public String getOsName() {
+        return fromProperty(Props.OS_NAME);
+    }
+    
+    public String getOsVersion() {
+        return fromProperty(Props.OS_VERSION);
+    }
 
     public Environment getEnvironment() {
         return environment;
@@ -151,7 +176,6 @@ public final class Config {
 
     private String fromProperty(Props prop) {
         String value = config.getProperty(prop.getPropertyName());
-        checkNotNull(value, "The property '" + prop.getPropertyName() + "' has not been set.");
-        return value.trim();
+        return (value == null || value.trim().length() == 0) ? null : value.trim();
     }
 }

--- a/rest-client/src/main/resources/bridge-sdk.properties
+++ b/rest-client/src/main/resources/bridge-sdk.properties
@@ -1,0 +1,2 @@
+log.level = warn
+sdk.version = 5

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ClientManagerTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ClientManagerTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import org.sagebionetworks.bridge.rest.model.ClientInfo;
 import org.sagebionetworks.bridge.rest.model.Environment;
 import org.sagebionetworks.bridge.rest.model.SignIn;
 
@@ -54,5 +55,25 @@ public class ClientManagerTest {
         assertEquals(Environment.PRODUCTION, manager.getConfig().getEnvironment());
         assertEquals("dudeski", manager.getConfig().getDevName());
         assertEquals("debug", manager.getConfig().getLogLevel());
+    }
+    
+    @Test
+    public void testClientInfoLoadedFromPropsFile() {
+        SignIn signIn = new SignIn().study("study-identifier").email("account@email.com")
+                .password("account-password");
+        
+        ClientManager manager = new ClientManager.Builder().withSignIn(signIn).withClientSupplier(supplier).build();
+        
+        // These values are set in the test bridge-sdk.properties file, and we want to verify they
+        // are used to construct the clientInfo object, so this doesn't have to be hard-wired into
+        // the application.
+        ClientInfo info = manager.getClientInfo();
+        assertEquals("testName", info.getAppName());
+        assertEquals((Integer)33, info.getAppVersion());
+        assertEquals("Swankie Device", info.getDeviceName());
+        assertEquals("webOS", info.getOsName());
+        assertEquals("ultimate", info.getOsVersion());
+        assertEquals("BridgeJavaSDK", info.getSdkName());
+        assertEquals((Integer)5, info.getSdkVersion());
     }
 }

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ClientManagerTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ClientManagerTest.java
@@ -67,6 +67,7 @@ public class ClientManagerTest {
         // These values are set in the test bridge-sdk.properties file, and we want to verify they
         // are used to construct the clientInfo object, so this doesn't have to be hard-wired into
         // the application.
+        
         ClientInfo info = manager.getClientInfo();
         assertEquals("testName", info.getAppName());
         assertEquals((Integer)33, info.getAppVersion());

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ConfigTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ConfigTest.java
@@ -1,0 +1,17 @@
+package org.sagebionetworks.bridge.rest;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ConfigTest {
+
+    @Test
+    public void test() {
+        Config config = new Config();
+        assertEquals("5", config.getSdkVersion());
+        assertEquals("testName", config.getAppName());
+        assertEquals("warn", config.getLogLevel());
+    }
+    
+}

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactoryTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/gson/RuntimeTypeAdapterFactoryTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.rest.gson;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.StringWriter;
@@ -9,7 +8,6 @@ import java.io.Writer;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.sagebionetworks.bridge.rest.model.SurveyElement;
@@ -55,8 +53,6 @@ public class RuntimeTypeAdapterFactoryTest {
         JsonWriter writer = new JsonWriter(outputWriter);
         
         typeAdapter.write(writer, question);
-        System.out.println(outputWriter.toString());
-        
         assertTrue(outputWriter.toString().contains("\"type\":\"SurveyQuestion\""));
     }
 }

--- a/rest-client/src/test/resources/bridge-sdk.properties
+++ b/rest-client/src/test/resources/bridge-sdk.properties
@@ -1,0 +1,8 @@
+log.level = warn
+sdk.version = 5
+app.name = testName
+app.version = 33
+device.name = Swankie Device
+os.name = webOS
+os.version = ultimate
+languages = en,fr


### PR DESCRIPTION
If you want to. 

Also fixing fact that the default bridge-sdk.properties file needs to be in the rest-client jar, not the integration tests, because that's where we get the required sdk version value. It would be nice to update this as part of the build, but we can't use the semantic version number in the pom.

See https://sagebionetworks.jira.com/browse/BRIDGE-1588

Finally, fixing an NPE if no properties file has a languages entry (ours doesn't by default).