### PR TITLE
improve error handling for unknown URLs; add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.9</version>
+    <version>0.12.10</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.9</version>
+        <version>0.12.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ErrorResponseInterceptor.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ErrorResponseInterceptor.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.rest.exceptions.UnsupportedVersionException;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 
+import com.google.common.base.Strings;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 
@@ -52,22 +53,24 @@ class ErrorResponseInterceptor implements Interceptor {
         String url = response.request().url().toString();
         try {
             JsonElement node = RestUtils.GSON.fromJson(response.body().string(), JsonElement.class);
-            throwExceptionOnErrorStatus(url, response.code(), node);
+            throwExceptionOnErrorStatus(url, response.code(), node, null);
         } catch (BridgeSDKException e) {
             // rethrow known exceptions
             throw e;
         } catch (Throwable t) {
             t.printStackTrace();
-            throw new BridgeSDKException(response.message(), response.code(), url);
-        }        
+            throwExceptionOnErrorStatus(url, response.code(), null, response.message());
+        }
     }
-    
-    private void throwExceptionOnErrorStatus(String url, int statusCode, JsonElement node) {
-        // Not having a message is actually pretty bad
-        String message = "There has been an error on the server";
-        
-        if (node.getAsJsonObject().get("message") != null) {
-            message = node.getAsJsonObject().get("message").getAsString();
+
+    private void throwExceptionOnErrorStatus(String url, int statusCode, JsonElement node, String message) {
+        if (Strings.isNullOrEmpty(message)) {
+            if (node != null && node.getAsJsonObject().get("message") != null) {
+                message = node.getAsJsonObject().get("message").getAsString();
+            } else {
+                // Not having a message is actually pretty bad
+                message = "There has been an error on the server";
+            }
         }
 
         BridgeSDKException e;
@@ -75,12 +78,15 @@ class ErrorResponseInterceptor implements Interceptor {
             e = new NotAuthenticatedException(message, url);
         } else if (statusCode == 403) {
             e = new UnauthorizedException(message, url);
-        } else if (statusCode == 404 && message.length() > "not found.".length()) {
+        } else if (statusCode == 404) {
             e = new EntityNotFoundException(message, url);
         } else if (statusCode == 410) {
             e = new UnsupportedVersionException(message, url);
         } else if (statusCode == 412) {
-            UserSessionInfo session = RestUtils.GSON.fromJson(node, UserSessionInfo.class);
+            UserSessionInfo session = null;
+            if (node != null) {
+                session = RestUtils.GSON.fromJson(node, UserSessionInfo.class);
+            }
             e = new ConsentRequiredException("Consent required.", url, session);
         } else if (statusCode == 409 && message.contains("already exists")) {
             e = new EntityAlreadyExistsException(message, url);
@@ -88,16 +94,17 @@ class ErrorResponseInterceptor implements Interceptor {
             e = new ConcurrentModificationException(message, url);
         } else if (statusCode == 400 && message.contains("A published survey")) {
             e = new PublishedSurveyException(message, url);
-        } else if (statusCode == 400 && node.getAsJsonObject().get("errors") != null) {
-            Map<String, List<String>> errors = RestUtils.GSON.fromJson(node.getAsJsonObject().get("errors"),
-                    ERRORS_MAP_TYPE_TOKEN);
-            e = new InvalidEntityException(message, errors, url);
         } else if (statusCode == 400) {
-            e = new BadRequestException(message, url);
+            if (node != null && node.getAsJsonObject().get("errors") != null) {
+                Map<String, List<String>> errors = RestUtils.GSON.fromJson(node.getAsJsonObject().get("errors"),
+                        ERRORS_MAP_TYPE_TOKEN);
+                e = new InvalidEntityException(message, errors, url);
+            } else {
+                e = new BadRequestException(message, url);
+            }
         } else {
             e = new BridgeSDKException(message, statusCode, url);
         }
         throw e;
-    }  
-    
+    }
 }

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ErrorResponseInterceptorTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ErrorResponseInterceptorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 
@@ -8,14 +9,24 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import org.sagebionetworks.bridge.rest.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.rest.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.rest.exceptions.ConsentRequiredException;
+import org.sagebionetworks.bridge.rest.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.rest.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.rest.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.rest.exceptions.NotAuthenticatedException;
+import org.sagebionetworks.bridge.rest.exceptions.PublishedSurveyException;
+import org.sagebionetworks.bridge.rest.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.rest.exceptions.UnsupportedVersionException;
 
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor.Chain;
@@ -41,16 +52,107 @@ public class ErrorResponseInterceptorTest {
     
     @Mock
     ResponseBody body;
-    
-    @Test
-    public void interceptEntityNotFoundException() throws IOException {
+
+    @Before
+    public void setup() throws Exception {
         doReturn(request).when(chain).request();
         doReturn(response).when(chain).proceed(request);
-        doReturn(404).when(response).code();
         doReturn(request).when(response).request();
         doReturn(httpUrl).when(request).url();
+        //noinspection ResultOfMethodCallIgnored
         doReturn("http://someurl/").when(httpUrl).toString();
         doReturn(body).when(response).body();
+    }
+
+    @Test
+    public void ok200() throws Exception {
+        doReturn(200).when(response).code();
+        ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+        Response retval = interceptor.intercept(chain);
+        assertSame(response, retval);
+    }
+
+    @Test
+    public void publishedSurvey400() throws Exception {
+        doReturn(400).when(response).code();
+        doReturn("{\"message\":\"A published survey cannot be updated or deleted (only closed).\"}").when(body)
+                .string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(PublishedSurveyException e) {
+            assertEquals(400, e.getStatusCode());
+            assertEquals("A published survey cannot be updated or deleted (only closed).", e.getMessage());
+        }
+    }
+
+    @Test
+    public void badRequest400() throws Exception {
+        doReturn(400).when(response).code();
+        doReturn("{\"message\":\"Bad request\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(BadRequestException e) {
+            assertEquals(400, e.getStatusCode());
+            assertEquals("Bad request", e.getMessage());
+        }
+    }
+
+    @Test
+    public void unrecognizedUrl400() throws Exception {
+        // Play sends responses like these if you call an unrecognized URL.
+        doReturn(400).when(response).code();
+        doReturn("<html><body>Play returns HTML instead of JSON</body></html>").when(body).string();
+        doReturn("Play Framework does not recognize this URL").when(response).message();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(BadRequestException e) {
+            assertEquals(400, e.getStatusCode());
+            assertEquals("Play Framework does not recognize this URL", e.getMessage());
+        }
+    }
+
+    @Test
+    public void notAuthenticated401() throws Exception {
+        doReturn(401).when(response).code();
+        doReturn("{\"message\":\"Not signed in.\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(NotAuthenticatedException e) {
+            assertEquals(401, e.getStatusCode());
+            assertEquals("Not signed in.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void unauthorized403() throws Exception {
+        doReturn(403).when(response).code();
+        doReturn("{\"message\":\"Caller does not have permission to access this service.\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(UnauthorizedException e) {
+            assertEquals(403, e.getStatusCode());
+            assertEquals("Caller does not have permission to access this service.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void interceptEntityNotFoundException() throws IOException {
+        doReturn(404).when(response).code();
         doReturn("{\"message\":\"User not found.\"}").when(body).string();
         
         try {
@@ -62,20 +164,14 @@ public class ErrorResponseInterceptorTest {
             assertEquals("User not found.", e.getMessage());
         }
     }
-    
+
     @Test
     public void interceptInvalidEntityException() throws Exception {
         String json = Tests.unescapeJson("{'errors':{'field2':['error message 3','error message 4'],"+
                 "'field1':['error message 1','error message 2']},'statusCode':400,'endpoint':"+
                 "'http://endpoint/','message':'General error message'}");
         
-        doReturn(request).when(chain).request();
-        doReturn(response).when(chain).proceed(request);
         doReturn(400).when(response).code();
-        doReturn(request).when(response).request();
-        doReturn(httpUrl).when(request).url();
-        doReturn("http://someurl/").when(httpUrl).toString();
-        doReturn(body).when(response).body();
         doReturn(json).when(body).string();
         try {
             ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
@@ -91,6 +187,117 @@ public class ErrorResponseInterceptorTest {
             assertEquals("error message 3", errors.get("field2").get(0));
             assertEquals("error message 4", errors.get("field2").get(1));
         }
-        
+    }
+
+    @Test
+    public void entityAlreadyExists409() throws Exception {
+        doReturn(409).when(response).code();
+        doReturn("{\"message\":\"Survey already exists\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(EntityAlreadyExistsException e) {
+            assertEquals(409, e.getStatusCode());
+            assertEquals("Survey already exists", e.getMessage());
+        }
+    }
+
+    @Test
+    public void concurrentModification409() throws Exception {
+        doReturn(409).when(response).code();
+        doReturn("{\"message\":\"Survey has the wrong version number\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(ConcurrentModificationException e) {
+            assertEquals(409, e.getStatusCode());
+            assertEquals("Survey has the wrong version number", e.getMessage());
+        }
+    }
+
+    @Test
+    public void unsupportedVersion410() throws Exception {
+        doReturn(410).when(response).code();
+        doReturn("{\"message\":\"This app version is not supported. Please update.\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(UnsupportedVersionException e) {
+            assertEquals(410, e.getStatusCode());
+            assertEquals("This app version is not supported. Please update.", e.getMessage());
+        }
+    }
+
+    // branch coverage: This is not actually possible, but we should test for it to make sure our code can handle it.
+    @Test
+    public void consentRequired412NoSession() throws Exception {
+        doReturn(412).when(response).code();
+        doReturn("Missing session info!").when(body).string();
+        doReturn("Missing session info!").when(response).message();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(ConsentRequiredException e) {
+            assertEquals(412, e.getStatusCode());
+            assertEquals("Consent required.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void serverError500() throws Exception {
+        doReturn(500).when(response).code();
+        doReturn("{\"message\":\"Something went terribly wrong!\"}").when(body).string();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(BridgeSDKException e) {
+            assertEquals(500, e.getStatusCode());
+            assertEquals("Something went terribly wrong!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void serviceUnavailable503() throws Exception {
+        // This might happen if the load balancer is overloaded.
+        doReturn(503).when(response).code();
+        doReturn("503 Service Unavailable").when(body).string();
+        doReturn("Load balancer error message").when(response).message();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(BridgeSDKException e) {
+            assertEquals(503, e.getStatusCode());
+            assertEquals("Load balancer error message", e.getMessage());
+        }
+    }
+
+    // branch coverage: Not sure if this is possible, but we should test for it.
+    @Test
+    public void unknownErrorInvalidBodyNoMessage() throws Exception {
+        // This might happen if the load balancer is overloaded.
+        doReturn(500).when(response).code();
+        doReturn("Invalid response body").when(body).string();
+        doReturn(null).when(response).message();
+
+        try {
+            ErrorResponseInterceptor interceptor = new ErrorResponseInterceptor();
+            interceptor.intercept(chain);
+            fail("Should have thrown exception");
+        } catch(BridgeSDKException e) {
+            assertEquals(500, e.getStatusCode());
+            assertEquals("There has been an error on the server", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Right now, if you call BridgePF with an unrecognized URL, Play Framework throws a 400 with an HTML response body. This causes the JavaSDK ErrorResponseInterceptor to fail to parse the JSON and return a BridgeSDKException w/ status 400 instead of a BadRequestException.

This change makes it so the exception selection code is still called even if JSON parsing fails. This also cleans up some of the error handling logic and adds a suite of tests.

Testing done:
* mvn verify (unit tests and other validation)
* Manual Test: Changed URLs in local server. Pulled in changes to Integ Tests and ran UploadTest against local server. Verified in test output that a BadRequestException was thrown instead of a BridgeSDKException.