### PR TITLE
update SchemaType enum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.11</version>
+    <version>0.12.12</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.11</version>
+        <version>0.12.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/swagger.json
+++ b/rest-client/swagger.json
@@ -4280,7 +4280,8 @@
       "type": "string",
       "enum": [
         "ios_data",
-        "ios_survey"
+        "ios_survey",
+        "upload_v2"
       ]
     },
     "SynapseExporterStatus": {


### PR DESCRIPTION
For whatever reason, Swagger will truncate enum prefixes. We have an enum UploadSchemaType with values ios_data and ios_survey. This generates an enum with values DATA and SURVEY.

This is a problem because we plan on adding non-iOS types to our enum in the near future. (Specifically, UPLOAD_V2, see https://sagebionetworks.jira.com/wiki/display/BRIDGE/Upload+Format+v2#UploadFormatv2-UploadSchemaFields) Swagger will then generate the enum as IOS_DATA, IOS_SURVEY, UPLOAD_V2, which will be a breaking change for our clients.

This change pre-emptively adds UPLOAD_V2, so clients can code against the correct enum values. This is a breaking change. Fortunately, only BridgeIntegrationTests uses these. (BridgeEX currently uses the old JavaSDK, but we're currently migrating it to use the new JavaSDK.)

Testing done:
* mvn verify (unit tests)
* tested with BridgeIntegrationTests