### PR TITLE
make ClientManager non-final so it can be mocked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.13</version>
+    <version>0.12.14</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.13</version>
+        <version>0.12.14</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ClientManager.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ClientManager.java
@@ -53,7 +53,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>The ClientManager contacts our production servers unless you configure another 
  * <code>Environment</code>.</p>
  */
-public final class ClientManager {
+public class ClientManager {
     
     static interface ClientSupplier {
         ApiClientProvider get(String hostUrl, String userAgent, String acceptLanguage);
@@ -117,7 +117,7 @@ public final class ClientManager {
      *         Class representing the service
      * @return service client
      */
-    public final <T> T getClient(Class<T> service) {
+    public <T> T getClient(Class<T> service) {
         return apiClientProvider.getClient(service, signIn);
     }
     


### PR DESCRIPTION
Consumers such as BridgeEX and Bridge-Reporter need to be able to mock ClientManager so they can write unit tests.

Testing done:
* mvn verify (unit tests)
* wrote Bridge-Reporter unit tests against this