### PR TITLE
add createdOnTimeZone to HealthDataRecord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.23</version>
+    <version>0.12.24</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.23</version>
+        <version>0.12.24</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/swagger.json
+++ b/rest-client/swagger.json
@@ -5494,6 +5494,10 @@
           "format": "date-time",
           "description": "ISO timestamp of when the data record was created, as reported by the submitting app"
         },
+        "createdOnTimeZone": {
+          "type": "string",
+          "description": "The original timezone of the createdOn timestamp, expressed as a 4-digit string with sign. For example, -0800, +0900"
+        },
         "data": {
           "type": "object",
           "description": "JSON map with key value pairs representing the record's data."


### PR DESCRIPTION
Added createdOnTimeZone to HealthDataRecord. See https://sagebionetworks.jira.com/browse/BRIDGE-1658

swagger.json is generated from https://github.com/Sage-Bionetworks/BridgeDocs/pull/105

This is primarily to facilitate integration tests.