### PR TITLE
Have AuthenticationHandler help purge cached sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.12.28</version>
+    <version>0.12.29</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.12.28</version>
+        <version>0.12.29</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/AuthenticationHandler.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/AuthenticationHandler.java
@@ -46,6 +46,7 @@ class AuthenticationHandler implements Authenticator, Interceptor {
     public okhttp3.Request authenticate(Route route, okhttp3.Response response) throws IOException {
         // if we reach this part of the code, the server had returned a 401 and userSession is
         // invalid
+        userSessionInfoProvider.purgeCachedSession(this.userSession);
         this.userSession = null;
 
         if (tryCount >= MAX_TRIES || !isValidSignIn(signIn)) {

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/UserSessionInfoProvider.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/UserSessionInfoProvider.java
@@ -63,4 +63,14 @@ public class UserSessionInfoProvider {
 
         return sessionInterceptor.getSession(signIn);
     }
+
+    /**
+     * Removes a session from the cache. This should be called if a session returned by this instance turns out to be
+     * no longer valid.
+     *
+     * @param session the user's session
+     */
+    void purgeCachedSession(UserSessionInfo session) {
+        sessionInterceptor.removeSession(session);
+    }
 }


### PR DESCRIPTION
* UserSessionInterceptor does not have access to the sessionToken or
signIn that was used by AuthenticationHandler behind the scenes
* AuthenticationHandler looks like the most reliable place to detect
session expiry
* Last change in 0.12.28 fixes signOut, but there are other ways token
can be expired