### PR TITLE
UserConsentHistory.imageData should be String, not byte[]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.13.2</version>
+    <version>0.13.3</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.2</version>
+        <version>0.13.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/user_consent_history.yml
+++ b/rest-api/src/main/resources/definitions/user_consent_history.yml
@@ -19,7 +19,6 @@ properties:
         description: ISO 8601 date string (e.g. "YYYY-MM-DD").
     imageData:
         type: string
-        format: byte
         description: The signature image in a base 64 encoding.
     imageMimeType:
         type: string

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.2</version>
+        <version>0.13.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
ConsentSignature.imageData is a regular String. We have nothing on the server-side enforcing that this is a Base64 encoded String (even though it's supposed to). Consequently, some imageData isn't properly Base64 encoded (generally stray newlines), which causes getParticipant to fail when called through the JavaSDK.

This changes UserConsentHistory.imageData to a String, to maintain compatibility with the server.

Testing done: Manually tested with a test script, running against some intentionally broken data.