### PR TITLE
Update to new participant report APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.13.7</version>
+    <version>0.13.8</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.7</version>
+        <version>0.13.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/index.yml
+++ b/rest-api/src/main/resources/definitions/index.yml
@@ -224,6 +224,8 @@ NotificationTopicList:
     $ref: ./paged_resources/notification_topic.yml
 ReportDataList:
     $ref: ./paged_resources/report_data.yml
+ForwardCursorReportDataList:
+    $ref: ./paged_resources/forward_cursor_report_data.yml
 ReportIndexList:
     $ref: ./paged_resources/report_index.yml
 ScheduleList:

--- a/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_report_data.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_report_data.yml
@@ -1,0 +1,10 @@
+type: object
+readOnly: true
+allOf:
+    - $ref: ./forward_cursor_paged_resource_list.yml
+    - properties:
+        items:
+            type: array
+            readOnly: true
+            items:
+                $ref: ../report_data.yml

--- a/rest-api/src/main/resources/definitions/report_data.yml
+++ b/rest-api/src/main/resources/definitions/report_data.yml
@@ -1,7 +1,8 @@
 description:
-    The JSON data for one time point of a report (curently a day expressed in the format YYYY-MM-DD). 
-    Data can be for a study as a whole or a report on a single participant depending on the endpoint 
-    that is used to persist the data in Bridge. 
+    The JSON data for one time point of a report (either a local date in the format YYYY-MM-DD, or an 
+    ISO 8601 timestamp; report records should all use one or the other format consistently). Data can 
+    be for a study as a whole or a report on a single participant depending on the endpoint that is 
+    used to persist the data in Bridge. 
 type: object
 required:
     - date
@@ -9,8 +10,15 @@ required:
 properties:
     date:
         type: string
+        description: The date (whether local or an ISO timestamp) of the report data. 
+    localDate:
+        type: string
         format: date
-        description: The date (YYYY-MM-DD) of the report data. 
+        description: The date expressed as a LocalDate (YYYY-MM-DD)
+    dateTime:
+        type: string
+        format: date-time
+        description: The date expressed as an ISO 8601 timestamp.
     data:
         type: object
         description: An arbitrary JSON object containing whatever data should be saved for a report.

--- a/rest-api/src/main/resources/paths/index.yml
+++ b/rest-api/src/main/resources/paths/index.yml
@@ -47,6 +47,8 @@
     $ref: ./participants/v3_participants.yml
 /v3/participants/self:
     $ref: ./participants/v3_participants_self.yml
+/v3/participants/reports:
+    $ref: ./participants/v3_participants_reports.yml
 /v3/participants/{userId}:
     $ref: ./participants/v3_participants_userId.yml
 /v3/participants/{userId}/uploads:
@@ -87,6 +89,8 @@
     $ref: ./participants/v3_participants_userId_activities_surveys_surveyGuid.yml
 /v3/participants/{userId}/activities/compoundactivities/{taskId}:
     $ref: ./participants/v3_participants_userId_activities_compoundactivities_taskId.yml
+/v4/participants/{userId}/reports/{identifier}:
+    $ref: ./participants/v4_participants_userId_reports_identifier.yml
 
 # Shared Modules
 /v3/sharedmodules/{moduleId}/import:
@@ -149,6 +153,8 @@
     $ref: ./users/v3_users_self_emailData.yml
 /v3/users/self/reports/{identifier}:
     $ref: ./users/v3_users_self_reports_identifier.yml
+/v4/users/self/reports/{identifier}:
+    $ref: ./users/v4_users_self_reports_identifier.yml
 
 # Reports
 /v3/reports:
@@ -159,6 +165,8 @@
     $ref: ./reports/v3_reports_identifier_index.yml
 /v3/reports/{identifier}/{date}:
     $ref: ./reports/v3_reports_identifier_date.yml
+/v4/reports/{identifier}:
+    $ref: ./reports/v4_reports_identifier.yml
 
 # Surveys
 /v3/surveys:

--- a/rest-api/src/main/resources/paths/participants/v3_participants_reports.yml
+++ b/rest-api/src/main/resources/paths/participants/v3_participants_reports.yml
@@ -1,8 +1,8 @@
 get:
-    operationId: getStudyReportIndices
-    summary: Get list of report indices for studies
+    operationId: getParticipantReportIndices
+    summary: Get list of report indices for participants
     tags:
-        - StudyReports
+        - ParticipantReports
         - _For Consented Users
     security:
         - BridgeSecurity: []

--- a/rest-api/src/main/resources/paths/participants/v3_participants_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/participants/v3_participants_reports_identifier.yml
@@ -6,7 +6,7 @@ post:
         the worker must provide the healthCode of the target user (this endpoint allows external 
         processes working with data from Synapse to write reports back to Bridge). 
     tags:
-        - Reports
+        - ParticipantReports
         - _For Workers
     security:
         - BridgeSecurity: []
@@ -32,7 +32,7 @@ delete:
         are not normally deleted, but this endpoint allows the index identifiers to be deleted 
         during testing.
     tags:
-        - Reports
+        - ParticipantReports
         - _For Admins
     security:
         - BridgeSecurity: []

--- a/rest-api/src/main/resources/paths/participants/v3_participants_userId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/participants/v3_participants_userId_reports_identifier.yml
@@ -2,7 +2,7 @@ get:
     operationId: getUsersParticipantReportRecords
     summary: Get participant report records
     tags:
-        - Reports
+        - ParticipantReports
         - _For Researchers
     security:
         - BridgeSecurity: []
@@ -20,46 +20,3 @@ get:
             $ref: ../../responses/401.yml
         403:
             $ref: ../../responses/403_not_researcher.yml
-post:
-    operationId: addParticipantReportRecord
-    summary: Add a participant report record
-    tags:
-        - Reports
-        - _For Developers
-    security:
-        - BridgeSecurity: []
-    parameters:
-        - $ref: ../../index.yml#/parameters/userId
-        - $ref: ../../index.yml#/parameters/identifier
-        - name: ReportData
-          required: true
-          in: body
-          schema:
-            $ref: ../../definitions/report_data.yml
-
-    responses:
-        201:
-            $ref: ../../responses/201_message.yml
-        401:
-            $ref: ../../responses/401.yml
-        403:
-            $ref: ../../responses/403_not_developer.yml            
-delete:
-    operationId: deleteAllParticipantReportRecords
-    summary: Delete a participant report (all records)
-    tags:
-        - Reports
-        - _For Developers
-        - _For Workers
-    security:
-        - BridgeSecurity: []
-    parameters:
-        - $ref: ../../index.yml#/parameters/userId
-        - $ref: ../../index.yml#/parameters/identifier
-    responses:
-        201:
-            $ref: ../../responses/200_message.yml
-        401:
-            $ref: ../../responses/401.yml
-        403:
-            $ref: ../../responses/403_not_developer_worker.yml

--- a/rest-api/src/main/resources/paths/participants/v3_participants_userId_reports_identifier_date.yml
+++ b/rest-api/src/main/resources/paths/participants/v3_participants_userId_reports_identifier_date.yml
@@ -2,7 +2,7 @@ delete:
     operationId: deleteParticipantReportRecord
     summary: Delete a record for a specific day of a participant report
     tags:
-        - Reports
+        - ParticipantReports
         - _For Developers
         - _For Workers
     security:

--- a/rest-api/src/main/resources/paths/participants/v4_participants_userId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/participants/v4_participants_userId_reports_identifier.yml
@@ -1,0 +1,67 @@
+get:
+    operationId: getUsersParticipantReportRecordsV4
+    summary: Get participant report records
+    tags:
+        - ParticipantReports
+        - _For Researchers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+        - $ref: ../../index.yml#/parameters/startTime
+        - $ref: ../../index.yml#/parameters/endTime
+        - $ref: ../../index.yml#/parameters/offsetKey
+        - $ref: ../../index.yml#/parameters/pageSize
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/paged_resources/forward_cursor_report_data.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_researcher.yml
+post:
+    operationId: addParticipantReportRecord
+    summary: Add a participant report record
+    tags:
+        - ParticipantReports
+        - _For Developers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+        - name: ReportData
+          required: true
+          in: body
+          schema:
+            $ref: ../../definitions/report_data.yml
+
+    responses:
+        201:
+            $ref: ../../responses/201_message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_developer.yml            
+delete:
+    operationId: deleteAllParticipantReportRecords
+    summary: Delete a participant report (all records)
+    tags:
+        - ParticipantReports
+        - _For Developers
+        - _For Workers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+    responses:
+        201:
+            $ref: ../../responses/200_message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_developer_worker.yml

--- a/rest-api/src/main/resources/paths/reports/v3_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/reports/v3_reports_identifier.yml
@@ -2,7 +2,7 @@ get:
     operationId: getStudyReportRecords
     summary: Get study report records
     tags:
-        - Reports
+        - StudyReports
         - _For Consented Users
     security:
         - BridgeSecurity: []
@@ -17,45 +17,3 @@ get:
                 $ref: ../../definitions/paged_resources/report_data.yml
         401:
             $ref: ../../responses/401.yml
-post:
-    operationId: addStudyReportRecord
-    summary: Add a record to a study report
-    tags:
-        - Reports
-        - _For Developers
-        - _For Workers
-    security:
-        - BridgeSecurity: []
-    parameters:
-        - $ref: ../../index.yml#/parameters/identifier
-        - name: body
-          description: Report data
-          required: true
-          in: body
-          schema:
-            $ref: ../../definitions/report_data.yml
-    responses:
-        201:
-            $ref: ../../responses/201_message.yml
-        401:
-            $ref: ../../responses/401.yml
-        403:
-            $ref: ../../responses/403_not_developer_worker.yml
-delete:
-    operationId: deleteAllStudyReportRecords
-    summary: Delete a study report (all records)
-    tags:
-        - Reports
-        - _For Developers
-        - _For Workers
-    security:
-        - BridgeSecurity: []
-    parameters:
-        - $ref: ../../index.yml#/parameters/identifier
-    responses:
-        200:
-            $ref: ../../responses/200_message.yml
-        401:
-            $ref: ../../responses/401.yml
-        403:
-            $ref: ../../responses/403_not_developer_worker.yml

--- a/rest-api/src/main/resources/paths/reports/v3_reports_identifier_date.yml
+++ b/rest-api/src/main/resources/paths/reports/v3_reports_identifier_date.yml
@@ -2,7 +2,7 @@ delete:
     operationId: deleteStudyReportRecord
     summary: Delete a record for a specific day of a study report
     tags:
-        - Reports
+        - StudyReports
         - _For Developers
         - _For Workers
     security:

--- a/rest-api/src/main/resources/paths/reports/v3_reports_identifier_index.yml
+++ b/rest-api/src/main/resources/paths/reports/v3_reports_identifier_index.yml
@@ -4,7 +4,7 @@ get:
     description: |
         Get the index (or metadata) for a set of report records. 
     tags:
-        - Reports
+        - StudyReports
         - _For Developers
         - _For Researchers
     security:
@@ -26,7 +26,7 @@ post:
     description: |
         Update the index (or metadata) for a set of report records.
     tags:
-        - Reports
+        - StudyReports
         - _For Developers
     security:
         - BridgeSecurity: []

--- a/rest-api/src/main/resources/paths/reports/v4_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/reports/v4_reports_identifier.yml
@@ -1,0 +1,63 @@
+get:
+    operationId: getStudyReportRecordsV4
+    summary: Get study report records
+    tags:
+        - StudyReports
+        - _For Consented Users
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/identifier
+        - $ref: ../../index.yml#/parameters/startTime
+        - $ref: ../../index.yml#/parameters/endTime
+        - $ref: ../../index.yml#/parameters/offsetKey
+        - $ref: ../../index.yml#/parameters/pageSize
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/paged_resources/forward_cursor_report_data.yml
+        401:
+            $ref: ../../responses/401.yml
+post:
+    operationId: addStudyReportRecord
+    summary: Add a record to a study report
+    tags:
+        - StudyReports
+        - _For Developers
+        - _For Workers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/identifier
+        - name: body
+          description: Report data
+          required: true
+          in: body
+          schema:
+            $ref: ../../definitions/report_data.yml
+    responses:
+        201:
+            $ref: ../../responses/201_message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_developer_worker.yml
+delete:
+    operationId: deleteAllStudyReportRecords
+    summary: Delete a study report (all records)
+    tags:
+        - StudyReports
+        - _For Developers
+        - _For Workers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/identifier
+    responses:
+        200:
+            $ref: ../../responses/200_message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_developer_worker.yml

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId_reports_identifier.yml
@@ -5,7 +5,7 @@ get:
         Get public study report records (no authentication is needed, but index for the report must be marked as 
         public or the server will return 404 for the report). Only study reports may be made public.
     tags:
-        - Reports
+        - StudyReports
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
         - $ref: ../../index.yml#/parameters/identifier
@@ -17,13 +17,13 @@ get:
             schema:
                 $ref: ../../definitions/paged_resources/report_data.yml
 post:
-    operationId: saveReportForStudy
+    operationId: saveReportForWorker
     summary: save report for a study
     description: |
          Save a report for a specified study with arbitrary report id given by wokers into bridgePF.
     tags:
         - Studies
-        - Reports
+        - StudyReports
         - _For Workers
     security:
         - BridgeSecurity: []

--- a/rest-api/src/main/resources/paths/users/v3_users_self_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/users/v3_users_self_reports_identifier.yml
@@ -6,7 +6,7 @@ get:
         account. Note that this call does not require consent, but does require authentication. 
     tags:
         - Users
-        - Reports
+        - ParticipantReports
         - _For Consented Users
     security:
         - BridgeSecurity: []

--- a/rest-api/src/main/resources/paths/users/v4_users_self_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/users/v4_users_self_reports_identifier.yml
@@ -1,0 +1,51 @@
+get:
+    operationId: getParticipantReportRecordsV4
+    summary: Get a participant report
+    description: |
+        Get the records for a specific participant report. Participants can get reports for their own 
+        account. Note that this call does not require consent, but does require authentication. 
+    tags:
+        - Users
+        - ParticipantReports
+        - _For Consented Users
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/identifier
+        - $ref: ../../index.yml#/parameters/startTime
+        - $ref: ../../index.yml#/parameters/endTime
+        - $ref: ../../index.yml#/parameters/pageSize
+        - $ref: ../../index.yml#/parameters/offsetKey
+    responses:
+        200:
+            description: Report records for the participant
+            schema:
+                $ref: ../../definitions/paged_resources/forward_cursor_report_data.yml
+        401:
+            $ref: ../../responses/401.yml
+post:
+    operationId: saveParticipantReportRecordsV4
+    summary: Save a participant report record
+    description: |
+        Save a report record. If a record exists at the given DateTime value, it will be replaced with this 
+        report record. Note that this call does not require consent, but does require authentication. 
+    tags:
+        - Users
+        - ParticipantReports
+        - _For Consented Users
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/identifier
+        - name: body
+          required: true
+          in: body
+          schema:
+              $ref: ../../definitions/report_data.yml
+    responses:
+        200:
+            description: Report records for the participant
+            schema:
+                $ref: ../../definitions/message.yml
+        401:
+            $ref: ../../responses/401.yml

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.7</version>
+        <version>0.13.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Also split ReportsApi into StudyReportsApi and ParticipantReportsApi. Now there are type-safe methods for getting study or participant report indices.