### PR TITLE
make UserSessionInfoProvider publicly accessible for BridgeAndroidSDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.13.18</version>
+    <version>0.13.20</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.18</version>
+        <version>0.13.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.18</version>
+        <version>0.13.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ApiClientProvider.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ApiClientProvider.java
@@ -41,7 +41,7 @@ public class ApiClientProvider {
 
     // To build the ClientManager on this class, we need to have access to the session that is persisted
     // by the HTTP interceptors.
-    UserSessionInfoProvider getUserSessionInfoProvider(SignIn signIn) {
+    public UserSessionInfoProvider getUserSessionInfoProvider(SignIn signIn) {
         return sessionProviders.get(signIn);
     }
     

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/UserSessionInfoProvider.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/UserSessionInfoProvider.java
@@ -18,7 +18,7 @@ import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
  * a session doesn't exist (hasn't been captured), it authenticates. The authentication causes the interceptor to 
  * capture the session, then you can return it.
  */
-class UserSessionInfoProvider {
+public class UserSessionInfoProvider {
     private static final Logger LOG = LoggerFactory.getLogger(UserSessionInfoProvider.class);
 
     private final AuthenticationApi authenticationApi;
@@ -33,7 +33,7 @@ class UserSessionInfoProvider {
         this.signIn = signIn;
     }
     
-    synchronized UserSessionInfo getSession() {
+    public synchronized UserSessionInfo getSession() {
         return session;
     }
     
@@ -44,7 +44,7 @@ class UserSessionInfoProvider {
      * @return session info for the user
      * @throws IOException problem while signing in
      */
-    synchronized UserSessionInfo retrieveSession() throws IOException {
+    public synchronized UserSessionInfo retrieveSession() throws IOException {
         if (session != null) {
             return session;
         }


### PR DESCRIPTION
BridgeAndroidSDK uses ApiClientProvider but not ClientManager. To prevent a significant refactor of BridgeAndroidSDK, we decided to just make UserSessionInfoProvider public again.

Testing done:
* mvn verify (unit tests, etc)
* tested with BridgeAndroidSDK and mPower-Android