### PR TITLE
User Data Download should use JSON body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.13.30</version>
+    <version>0.13.31</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.30</version>
+        <version>0.13.31</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/date_range.yml
+++ b/rest-api/src/main/resources/definitions/date_range.yml
@@ -1,0 +1,12 @@
+description: |
+    Model object representing a date range, which includes start date and end date as calendar dates (YYYY-MM-DD).
+type: object
+properties:
+    startDate:
+        type: string
+        format: date
+        description: Start date of the date range (YYYY-MM-DD).
+    endDate:
+        type: string
+        format: date
+        description: Start date of the date range (YYYY-MM-DD).

--- a/rest-api/src/main/resources/definitions/index.yml
+++ b/rest-api/src/main/resources/definitions/index.yml
@@ -75,6 +75,8 @@ CustomActivityEventRequest:
     $ref: ./custom_activity_event_request.yml
 DataGroups:
     $ref: ./data_groups.yml
+DateRange:
+    $ref: ./date_range.yml
 Email:
     $ref: ./email.yml
 EmailSignIn:

--- a/rest-api/src/main/resources/paths/users/v3_users_self_emailData.yml
+++ b/rest-api/src/main/resources/paths/users/v3_users_self_emailData.yml
@@ -11,8 +11,12 @@ post:
     security:
         - BridgeSecurity: []
     parameters:
-        - $ref: ../../index.yml#/parameters/startDate
-        - $ref: ../../index.yml#/parameters/endDate
+        - name: DateRange
+          in: body
+          description: start- and endDate of the request.
+          required: true
+          schema:
+            $ref: ../../definitions/date_range.yml
     responses:
         202:
             $ref: ../../responses/202_message.yml

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.13.30</version>
+        <version>0.13.31</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
User Data Download was originally implemented using the HTTP request body to pass in start and end date. At some point, we added the ability to call using query parameters, then made a change that broke the HTTP request body.

Due to limitations in Swagger (can't make different APIs with the same method and URL) and Retrofit (can't send a null body), it's impossible to support both call patterns simultaneously. Since the iOS client already uses the HTTP request body, and since Android apps are only just starting development, we're going to deprecate the query params version.

This change migrate the Java SDK from the query param version to the JSON body version.

Testing done:
* mvn verify
* created minimal integ test for User Data Download

See also:
* https://github.com/Sage-Bionetworks/BridgePF/pull/1632