### PR TITLE
ClientManager to use SignIn.getStudy instead of Config.getStudy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.14.7</version>
+    <version>0.14.8</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.14.7</version>
+        <version>0.14.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.14.7</version>
+        <version>0.14.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ClientManager.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ClientManager.java
@@ -88,7 +88,7 @@ public class ClientManager {
         String acceptLanguage = RestUtils.getAcceptLanguage(acceptLanguages);
 
         this.authenticatedClientProvider =
-                new ApiClientProvider(hostURL, userAgent, acceptLanguage, config.getStudyIdentifier())
+                new ApiClientProvider(hostURL, userAgent, acceptLanguage, signIn.getStudy())
                         .getAuthenticatedClientProviderBuilder()
                         .withPhone(signIn.getPhone())
                         .withEmail(signIn.getEmail())


### PR DESCRIPTION
ClientManager uses Config.getStudy() instead of SignIn.getStudy(). This is fine for apps, since they only operate on one study. This works less well for Integ Tests and for other worker tasks that operate across studies.

We recreate the ClientManager for each user, so it's fine to use SignIn.getStudy() here.

Testing done: https://github.com/Sage-Bionetworks/BridgeIntegrationTests/pull/238
* Verified that this failed for the old JavaSDK, and that it succeeds for the new JavaSDK.