### PR TITLE
Update RestUtils.toUserAgent() method to allow a much winder range of UA strings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.15.1</version>
+    <version>0.15.2</version>
 
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.1</version>
+        <version>0.15.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.1</version>
+        <version>0.15.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
@@ -51,7 +51,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
@@ -198,20 +198,47 @@ public class RestUtils {
         if (info == null) {
             return null;
         }
-        List<String> stanzas = Lists.newArrayListWithCapacity(3);
-        if (isNotBlank(info.getAppName()) && info.getAppVersion() != null) {
-            stanzas.add(String.format("%s/%s", info.getAppName(), info.getAppVersion()));
+        // Send what is available. The server can handle all meaningful combinations.
+        StringBuilder sb = new StringBuilder();
+        if (isNotBlank(info.getAppName()) || info.getAppVersion() != null) {
+            if (isNotBlank(info.getAppName())) {
+                sb.append(info.getAppName());
+            }
+            if (info.getAppVersion() != null) {
+                sb.append("/");
+                sb.append(info.getAppVersion());
+            }
         }
-        if (isNotBlank(info.getDeviceName()) && isNotBlank(info.getOsName()) && isNotBlank(info.getOsVersion())) {
-            stanzas.add(String.format("(%s; %s/%s)", info.getDeviceName(), info.getOsName(), info.getOsVersion()));
+        if (isNotBlank(info.getDeviceName()) || isNotBlank(info.getOsName()) || isNotBlank(info.getOsVersion())) {
+            sb.append(" (");
+            // Only include device name if there's also os, this is one ambiguity we cannot parse.
+            if (isNotBlank(info.getDeviceName())) {
+                sb.append(info.getDeviceName());
+                sb.append("; ");
+            }
+            if (isNotBlank(info.getOsName())) {
+                sb.append(info.getOsName());
+            }
+            if (isNotBlank(info.getOsVersion())) {
+                sb.append("/");
+                sb.append(info.getOsVersion());
+            }
+            sb.append(")");
         }
-        if (!stanzas.isEmpty() && isNotBlank(info.getSdkName()) && info.getSdkVersion() != null) {
-            stanzas.add(String.format("%s/%s", info.getSdkName(), info.getSdkVersion()));    
+        if (isNotBlank(info.getSdkName()) || info.getSdkVersion() != null) {
+            sb.append(" ");
+            if (isNotBlank(info.getSdkName())) {
+                sb.append(info.getSdkName());
+            }
+            if (info.getSdkVersion() != null) {
+                sb.append("/");
+                sb.append(info.getSdkVersion());
+            }
         }
-        if (stanzas.isEmpty()) {
+        if ("".equals(sb.toString())) {
             return null;
         }
-        return Joiner.on(" ").join(stanzas);
+        return sb.toString();
     }
     
     public static String getAcceptLanguage(List<String> langs) {

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
@@ -71,7 +71,7 @@ public class RestUtilsTest {
         clientInfo.setSdkName("BridgeJavaSDK");
         clientInfo.setSdkVersion(3);
         String userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 BridgeJavaSDK/3", userAgent);
+        assertEquals("AppName/1 (iPhone OS/2.0.0) BridgeJavaSDK/3", userAgent);
         
         clientInfo = new ClientInfo();
         clientInfo.setAppName("AppName");
@@ -82,7 +82,7 @@ public class RestUtilsTest {
         clientInfo.setSdkName("BridgeJavaSDK");
         clientInfo.setSdkVersion(3);
         userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 BridgeJavaSDK/3", userAgent);
+        assertEquals("AppName/1 (Device Name; /2.0.0) BridgeJavaSDK/3", userAgent);
         
         clientInfo = new ClientInfo();
         clientInfo.setAppName("AppName");
@@ -93,7 +93,7 @@ public class RestUtilsTest {
         clientInfo.setSdkName("BridgeJavaSDK");
         clientInfo.setSdkVersion(3);
         userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 BridgeJavaSDK/3", userAgent);
+        assertEquals("AppName/1 (Device Name; iPhone OS) BridgeJavaSDK/3", userAgent);
     }
     
     @Test

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
@@ -46,74 +46,56 @@ public class RestUtilsTest {
     }
     
     @Test
-    public void userAgentWithFullClientInfo() {
-        ClientInfo clientInfo = new ClientInfo();
-        clientInfo.setAppName("AppName");
-        clientInfo.setAppVersion(1);
-        clientInfo.setDeviceName("Device Name");
-        clientInfo.setOsName("iPhone OS");
-        clientInfo.setOsVersion("2.0.0");
-        clientInfo.setSdkName("BridgeJavaSDK");
-        clientInfo.setSdkVersion(3);
+    public void userAgentFormatting() {
+        assertInfo("appName", new ClientInfo().appName("appName"));
+        assertInfo("/2", new ClientInfo().appVersion(2));
+        assertInfo("appName/2", new ClientInfo().appName("appName").appVersion(2));
         
-        String userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 (Device Name; iPhone OS/2.0.0) BridgeJavaSDK/3", userAgent);
+        assertInfo("appName/2 sdkName", new ClientInfo().appName("appName").appVersion(2).sdkName("sdkName"));
+        assertInfo("appName/2 /4", new ClientInfo().appName("appName").appVersion(2).sdkVersion(4));
+        assertInfo("appName/2 sdkName/4",
+                new ClientInfo().appName("appName").appVersion(2).sdkName("sdkName").sdkVersion(4));
+        
+        assertInfo("appName (osName)", new ClientInfo().appName("appName").osName("osName"));
+        assertInfo("appName (/osVersion)", new ClientInfo().appName("appName").osVersion("osVersion"));
+        assertInfo("appName (osName/osVersion)",
+                new ClientInfo().appName("appName").osName("osName").osVersion("osVersion"));
+        
+        assertInfo("appName (deviceName; osName)",
+                new ClientInfo().appName("appName").deviceName("deviceName").osName("osName"));
+        assertInfo("appName (deviceName; /osVersion)",
+                new ClientInfo().appName("appName").deviceName("deviceName").osVersion("osVersion"));
+        assertInfo("appName (deviceName; osName/osVersion)",
+                new ClientInfo().appName("appName").deviceName("deviceName").osName("osName").osVersion("osVersion"));
+        
+        assertInfo("appName (osName) sdkName", new ClientInfo().appName("appName").osName("osName").sdkName("sdkName"));
+        assertInfo("appName (osName) /4", new ClientInfo().appName("appName").osName("osName").sdkVersion(4));
+        assertInfo("appName (osName) sdkName/4",
+                new ClientInfo().appName("appName").osName("osName").sdkName("sdkName").sdkVersion(4));
+        assertInfo("appName (deviceName; osName/osVersion) sdkName/4", new ClientInfo().appName("appName")
+                .deviceName("deviceName").osName("osName").osVersion("osVersion").sdkName("sdkName").sdkVersion(4));
+        
+        // Other examples from prior versions of this test.
+        assertInfo("AppName/1 (Device Name; iPhone OS/2.0.0) BridgeJavaSDK/3", new ClientInfo().appName("AppName").appVersion(1).deviceName("Device Name")
+                .osName("iPhone OS").osVersion("2.0.0").sdkName("BridgeJavaSDK").sdkVersion(3));
+        
+        assertInfo("AppName/1 (iPhone OS/2.0.0) BridgeJavaSDK/3", new ClientInfo().appName("AppName").appVersion(1)
+                .osName("iPhone OS").osVersion("2.0.0").sdkName("BridgeJavaSDK").sdkVersion(3));
+        
+        assertInfo("AppName/1 (Device Name; /2.0.0) BridgeJavaSDK/3", new ClientInfo().appName("AppName")
+                .appVersion(1).deviceName("Device Name").osVersion("2.0.0").sdkName("BridgeJavaSDK").sdkVersion(3));
+        
+        assertInfo("AppName/1 (Device Name; iPhone OS) BridgeJavaSDK/3", new ClientInfo().appName("AppName")
+                .appVersion(1).deviceName("Device Name").osName("iPhone OS").sdkName("BridgeJavaSDK").sdkVersion(3));
+        
+        assertInfo("AppName/1 BridgeJavaSDK/3",
+                new ClientInfo().appName("AppName").appVersion(1).sdkName("BridgeJavaSDK").sdkVersion(3));
+        
+        assertInfo("AppName/1", new ClientInfo().appName("AppName").appVersion(1));
     }
     
-    @Test
-    public void userAgentWithSomeDeviceInfo() {
-        ClientInfo clientInfo = new ClientInfo();
-        clientInfo.setAppName("AppName");
-        clientInfo.setAppVersion(1);
-        //no device name
-        clientInfo.setOsName("iPhone OS");
-        clientInfo.setOsVersion("2.0.0");
-        clientInfo.setSdkName("BridgeJavaSDK");
-        clientInfo.setSdkVersion(3);
-        String userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 (iPhone OS/2.0.0) BridgeJavaSDK/3", userAgent);
-        
-        clientInfo = new ClientInfo();
-        clientInfo.setAppName("AppName");
-        clientInfo.setAppVersion(1);
-        clientInfo.setDeviceName("Device Name");
-        //no OS name
-        clientInfo.setOsVersion("2.0.0");
-        clientInfo.setSdkName("BridgeJavaSDK");
-        clientInfo.setSdkVersion(3);
-        userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 (Device Name; /2.0.0) BridgeJavaSDK/3", userAgent);
-        
-        clientInfo = new ClientInfo();
-        clientInfo.setAppName("AppName");
-        clientInfo.setAppVersion(1);
-        clientInfo.setDeviceName("Device Name");
-        clientInfo.setOsName("iPhone OS");
-        //no OS version
-        clientInfo.setSdkName("BridgeJavaSDK");
-        clientInfo.setSdkVersion(3);
-        userAgent = RestUtils.getUserAgent(clientInfo);
-        assertEquals("AppName/1 (Device Name; iPhone OS) BridgeJavaSDK/3", userAgent);
-    }
-    
-    @Test
-    public void userAgentWithAppInfoAndSdk() {
-        ClientInfo clientInfo = new ClientInfo();
-        clientInfo.setAppName("AppName");
-        clientInfo.setAppVersion(1);
-        clientInfo.setSdkName("BridgeJavaSDK");
-        clientInfo.setSdkVersion(3);
-        
-        assertEquals("AppName/1 BridgeJavaSDK/3", RestUtils.getUserAgent(clientInfo));
-    }
-    
-    @Test
-    public void userAgentWithAppInfo() {
-        ClientInfo clientInfo = new ClientInfo();
-        clientInfo.setAppName("AppName");
-        clientInfo.setAppVersion(1);
-        
-        assertEquals("AppName/1", RestUtils.getUserAgent(clientInfo));
+    private void assertInfo(String expected, ClientInfo info) {
+        assertEquals(expected, RestUtils.getUserAgent(info));
     }
     
     @Test


### PR DESCRIPTION
This in turn allows us to remove a lot of unnecessary stuff in the integration tests to communicate filtering information to the server. It will be harder for all clients to circumvent filtering where it is wanted or intended.