### PR TITLE
Make all collections (arrays, objects-as-maps) required so empty collections are created as part of object construction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.15.19</version>
+    <version>0.15.20</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.19</version>
+        <version>0.15.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -1,5 +1,9 @@
 type: object
 discriminator: type
+required:
+    - roles
+    - dataGroups
+    - languages
 properties:
     firstName:
         type: string

--- a/rest-api/src/main/resources/definitions/account_summary_search.yml
+++ b/rest-api/src/main/resources/definitions/account_summary_search.yml
@@ -1,6 +1,9 @@
 description: |
     Search criteria to retrieve account summaries of study participants
 type: object
+required:
+    - allOfGroups
+    - noneOfGroups
 properties:
     pageSize:
         description: maximum number of records in each returned page

--- a/rest-api/src/main/resources/definitions/app_config.yml
+++ b/rest-api/src/main/resources/definitions/app_config.yml
@@ -1,6 +1,9 @@
 description: |
     An app configuration object.
 type: object
+required:
+    - surveyReferences
+    - schemaReferences
 properties:
     label:
         type: string

--- a/rest-api/src/main/resources/definitions/compound_activity.yml
+++ b/rest-api/src/main/resources/definitions/compound_activity.yml
@@ -6,6 +6,8 @@ description: A pointer to a compound activity, which represents multiple schemas
     as the key.
 required:
     - taskIdentifier
+    - schemaList
+    - surveyList
 properties:
     schemaList:
         type: array

--- a/rest-api/src/main/resources/definitions/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/compound_activity_definition.yml
@@ -4,6 +4,8 @@ description: A compound activity definition, which lives outside of but parallel
     and the scheduler will automatically resolve and populate the compound activity in returned scheduled activities.
 required:
     - taskId
+    - schemaList
+    - surveyList
 properties:
     schemaList:
         type: array

--- a/rest-api/src/main/resources/definitions/criteria.yml
+++ b/rest-api/src/main/resources/definitions/criteria.yml
@@ -5,6 +5,11 @@ description: |
     against which user information will be matched are described in the Criteria object. 
     See [Customizing Content for Participants](/articles/filtering.html) for a 
     fuller explanation. 
+required:
+    - allOfGroups
+    - noneOfGroups
+    - minAppVersions
+    - maxAppVersions
 properties:
     language:
         type: string

--- a/rest-api/src/main/resources/definitions/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/health_data_record.yml
@@ -3,6 +3,8 @@ description: |
      an upload record in the API.
 readOnly: true
 type: object
+required:
+    - userDataGroups
 properties:
     appVersion:
         type: string

--- a/rest-api/src/main/resources/definitions/paged_resources/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/account_summary.yml
@@ -3,6 +3,8 @@ readOnly: true
 description: Payload returning a list of [AccountSummary](/#AccountSummary) records.
 allOf:
     - $ref: ./paged_resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/activity.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: './resource_list.yml'
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/activity_event.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/activity_event.yml
@@ -1,5 +1,7 @@
 type: object
 readOnly: true
+required:
+    - items
 properties:
     items:
         type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/app_config.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/app_config.yml
@@ -1,5 +1,7 @@
 type: object
 readOnly: true
+required:
+    - items
 properties:
     items:
         type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/compound_activity_definition.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: './resource_list.yml'
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/external_identifier.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/external_identifier.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./forward_cursor_paged_resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_report_data.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_report_data.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./forward_cursor_paged_resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_scheduled_activity.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./forward_cursor_paged_resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/notification_registration.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/notification_registration.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/notification_topic.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/notification_topic.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/paged_string.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/paged_string.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./forward_cursor_paged_resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/report_data.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/report_data.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/report_index.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/report_index.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/schedule.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/schedule.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/schedule_plan.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/schedule_plan.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity_v4.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity_v4.yml
@@ -4,6 +4,8 @@ description: |
     The endpoint takes a startTime (inclusive) and endTime (exclusive) to form a time range (up to 15 days). Any activity that has an active time window (from its scheduled time to its expiration time) that falls on or after the start time, and before the end time, is included in the returned tasks.
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/shared_module_metadata.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/shared_module_metadata.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/string.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/string.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/study.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/study.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/study_consent.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/study_consent.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/subpopulation.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/subpopulation.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/subscription_status.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/subscription_status.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/survey.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/survey.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/upload.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/upload.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./forward_cursor_paged_resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/paged_resources/upload_schema.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/upload_schema.yml
@@ -2,6 +2,8 @@ type: object
 readOnly: true
 allOf:
     - $ref: ./resource_list.yml
+    - required:
+        - items
     - properties:
         items:
             type: array

--- a/rest-api/src/main/resources/definitions/request_info.yml
+++ b/rest-api/src/main/resources/definitions/request_info.yml
@@ -14,6 +14,8 @@ readOnly: true
 required:
     - userId
     - studyIdentifier
+    - languages
+    - userDataGroups
 properties:
     userId:
         type: string

--- a/rest-api/src/main/resources/definitions/shared_module_metadata.yml
+++ b/rest-api/src/main/resources/definitions/shared_module_metadata.yml
@@ -4,6 +4,7 @@ required:
     - id
     - name
     - version
+    - tags
 properties:
     id:
         type: string

--- a/rest-api/src/main/resources/definitions/study.yml
+++ b/rest-api/src/main/resources/definitions/study.yml
@@ -9,6 +9,7 @@ required:
     - identifier
     - consentNotificationEmail
     - version
+    - userProfileAttributes
 properties:
     name:
         type: string

--- a/rest-api/src/main/resources/definitions/study.yml
+++ b/rest-api/src/main/resources/definitions/study.yml
@@ -10,6 +10,12 @@ required:
     - consentNotificationEmail
     - version
     - userProfileAttributes
+    - uploadMetadataFieldDefinitions
+    - taskIdentifiers
+    - activityEventKeys
+    - dataGroups
+    - appleAppLinks
+    - androidAppLinks
 properties:
     name:
         type: string

--- a/rest-api/src/main/resources/definitions/study_participant.yml
+++ b/rest-api/src/main/resources/definitions/study_participant.yml
@@ -2,6 +2,8 @@ allOf:
     - $ref: ./abstract_study_participant.yml
     - description: |
         The full record about a study participant.
+    - required:
+        - consentHistories
     - properties:
         healthCode:
             type: string

--- a/rest-api/src/main/resources/definitions/survey_element.yml
+++ b/rest-api/src/main/resources/definitions/survey_element.yml
@@ -5,6 +5,8 @@ required:
     - guid
     - identifier
     - type
+    - beforeRules
+    - afterRules
 properties:
     guid:
         type: string

--- a/rest-api/src/main/resources/definitions/survey_rule.yml
+++ b/rest-api/src/main/resources/definitions/survey_rule.yml
@@ -13,6 +13,7 @@ type: object
 required:
     - operator
     - value
+    - dataGroups
 properties:
     operator:
         $ref: ./enums/operator.yml

--- a/rest-api/src/main/resources/definitions/upload.yml
+++ b/rest-api/src/main/resources/definitions/upload.yml
@@ -5,6 +5,7 @@ required:
     - schemaRevision
     - status
     - requestedOn
+    - validationMessageList
 properties:
     uploadId:
         type: string

--- a/rest-api/src/main/resources/definitions/upload_field_definition.yml
+++ b/rest-api/src/main/resources/definitions/upload_field_definition.yml
@@ -6,6 +6,7 @@ type: object
 required:
     - name
     - type
+    - multiChoiceAnswerList
 properties:
     name:
         type: string

--- a/rest-api/src/main/resources/definitions/upload_schema.yml
+++ b/rest-api/src/main/resources/definitions/upload_schema.yml
@@ -7,6 +7,8 @@ required:
     - revision
     - schemaId
     - version
+    - minAppVersions
+    - maxAppVersions
     - fieldDefinitions
 properties:
     maxAppVersions:

--- a/rest-api/src/main/resources/definitions/upload_validation_status.yml
+++ b/rest-api/src/main/resources/definitions/upload_validation_status.yml
@@ -1,5 +1,7 @@
 type: object
 readOnly: true
+required:
+    - messageList
 properties:
     id:
         type: string

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.19</version>
+        <version>0.15.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This behavior changed with an update to the Swagger libraries, and we decided to maintain the generated code behavior by changing how we define things in Swagger.