### PR TITLE
bump version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.15.20</version>
+    <version>0.15.21</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.20</version>
+        <version>0.15.21</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.20</version>
+        <version>0.15.21</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Merge conflict caused the version number to not be bumped after the last checkin. This change fixes that.