### PR TITLE
need to make ScheduledActivity fields writable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.15.22</version>
+    <version>0.15.23</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.22</version>
+        <version>0.15.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/scheduled_activity.yml
@@ -8,7 +8,6 @@ properties:
         type: string
     schedulePlanGuid:
         type: string
-        readOnly: true
     startedOn:
         type: string
         format: date-time
@@ -20,23 +19,19 @@ properties:
     scheduledOn:
         type: string
         format: date-time
-        readOnly: true
         description: |
             The time at which the activity should be made available to the participant. It's fine to show the activity before this, but the user should not be able to start it until this time has passed. Time will be expressed in the time zone sent to the server to request the scheduled activities.
     expiresOn:
         type: string
         format: date-time
-        readOnly: true
         description: |
             The time after which this task should no longer be made available to the participant. It will also no longer be returned from the server API. Time will be expressed in the time zone sent to the server to request the scheduled activities.
     activity:
         $ref: ./activity.yml 
-        readOnly: true
     persistent:
         type: boolean
         description: |
             Is this activity persistent? If so, it will never be removed from the list of activities; the client may wish to provide different UI for such a task.
-        readOnly: true
     clientData:
         type: object
         description: |

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.15.22</version>
+        <version>0.15.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
In Android, we need to marshall and unmarshall ScheduledActivity into SQL-Lite form. When we reconstituate these from database, we need to be able to set these fields.