### PR TITLE
increase timeout to 30 sec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.16.14</version>
+    <version>0.16.15</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.16.14</version>
+        <version>0.16.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.16.14</version>
+        <version>0.16.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ApiClientProvider.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/ApiClientProvider.java
@@ -151,10 +151,11 @@ public class ApiClientProvider {
      * @return base http client builder
      */
     protected OkHttpClient.Builder getHttpClientBuilder() {
+        // TODO Timeouts should be easily configurable https://sagebionetworks.jira.com/browse/BRIDGE-2332
         return new OkHttpClient.Builder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
-                .writeTimeout(10, TimeUnit.SECONDS);
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS);
     }
 
     OkHttpClient.Builder getHttpClientBuilder(List<Interceptor> networkInterceptors,


### PR DESCRIPTION
0.01% of create user requests take up to 30 sec. Increase timeout to 30 sec to reduce the number of sporadic failures in integ tests.