### PR TITLE
Many small corrections and changes to improve the generated Java SDK files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.17.1</version>
+    <version>0.18.0</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.17.1</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -1,4 +1,5 @@
 type: object
+description: Common fields for the SignUp and StudyParticipant payloads. This is an abstract class that cannot be used directly through the API.
 required:
     - roles
     - dataGroups

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -5,17 +5,22 @@ readOnly: true
 properties:
     firstName:
         type: string
+        readOnly: true
         description: First (given) name of user.
     lastName:
         type: string
+        readOnly: true
         description: Last (family) name of user.
     email:
         type: string
+        readOnly: true
         description: Email address of user.
     phone:
         $ref: ./phone.yml
+        readOnly: true
     id: 
         type: string
+        readOnly: true
         description: An identifier assigned to this user, used to retrieve a study participant record.
     createdOn: 
         type: string
@@ -24,10 +29,13 @@ properties:
         description: ISO 8601 date and time that the user account was created.
     status:
         $ref: ./enums/account_status.yml
+        readOnly: true
     studyIdentifier:
         $ref: ./study_identifier.yml
+        readOnly: true
     substudyIds:
         type: array
+        readOnly: true
         description: The substudies this participant is associated to.
         items:
             type: string

--- a/rest-api/src/main/resources/definitions/cms_public_key.yml
+++ b/rest-api/src/main/resources/definitions/cms_public_key.yml
@@ -8,6 +8,7 @@ required:
 properties:
     publicKey:
         type: string
+        readOnly: true
         description: |
             Base 64 encoded version of the public key for CMS encryption of upload data.    
     type:

--- a/rest-api/src/main/resources/definitions/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/compound_activity_definition.yml
@@ -26,4 +26,4 @@ properties:
     type:
         type: string
         readOnly: true
-        description: "CompoundActivity"
+        description: "CompoundActivityDefinition"

--- a/rest-api/src/main/resources/definitions/config_reference.yml
+++ b/rest-api/src/main/resources/definitions/config_reference.yml
@@ -11,7 +11,3 @@ properties:
         type: integer
         format: int64
         description: Revision number
-    type:
-        type: string
-        readOnly: true
-        description: "ConfigReference"

--- a/rest-api/src/main/resources/definitions/config_reference.yml
+++ b/rest-api/src/main/resources/definitions/config_reference.yml
@@ -11,3 +11,7 @@ properties:
         type: integer
         format: int64
         description: Revision number
+    type:
+        type: string
+        readOnly: true
+        description: "ConfigReference"

--- a/rest-api/src/main/resources/definitions/consent_status.yml
+++ b/rest-api/src/main/resources/definitions/consent_status.yml
@@ -5,12 +5,15 @@ readOnly: true
 properties:
     name:
         type: string
+        readOnly: true
         description: The name of the subpopulation.
     subpopulationGuid:
         type: string
+        readOnly: true
         description: The GUID for the subpopulation of this consent.
     required:
         type: boolean
+        readOnly: true
         description: |
             Is this consent required? If required, the user must consent to it before being given access to the server (until signed, a 412 response is returned for most participant endpoints).
     signedOn:
@@ -20,9 +23,11 @@ properties:
         description: The date and time the referenced consent was signed and agreed to by the participant. If there is a signedOn value, consented will be equal to true.
     consented:
         type: boolean
+        readOnly: true
         description: Has the participant consented to this consent agreement? If the user has signed this consent, there should be a signedOn timestamp value.
     signedMostRecentConsent:
         type: boolean
+        readOnly: true
         description: |
             Was the consent to participate made against the most recently published version of this consent?
     type:

--- a/rest-api/src/main/resources/definitions/email_verification_status.yml
+++ b/rest-api/src/main/resources/definitions/email_verification_status.yml
@@ -6,6 +6,7 @@ required:
 properties:
     status:
         $ref: ./enums/account_status.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/health_data_record.yml
@@ -7,74 +7,93 @@ required:
 properties:
     appVersion:
         type: string
+        readOnly: true
         description: |
             App version, as reported by the app. Generally in the form "version 1.0.0, build 2". Must be 48 chars or less.
     createdOn:
         type: string
+        readOnly: true
         format: date-time
         description: ISO timestamp of when the data record was created, as reported by the submitting app
     createdOnTimeZone:
         type: string
+        readOnly: true
         description: The original timezone of the createdOn timestamp, expressed as a 4-digit string with sign. For example, -0800, +0900
     data:
         type: object
+        readOnly: true
         description: JSON map with key value pairs representing the record's data.
     id:
         type: string
+        readOnly: true
         description: A unique GUID for this record.
     metadata:
         type: object
+        readOnly: true
         description: |
             Arbitrary JSON blob of record metadata, as submitted by the app. For ResearchKit-based apps, this is info.json verbatim.
     phoneInfo:
         type: string
+        readOnly: true
         description: Phone info, for example "iPhone9,3" or "iPhone 5c (GSM)". Must be 48 chars or less.
     rawDataAttachmentId:
         type: string
+        readOnly: true
         description: |
             Attachment ID (S3 key) that contains the raw data. This is the unencrypted zip file for uploads, or JSON blob for directly submitted records
     schemaId:
         type: string
+        readOnly: true
         description: |
             [UploadSchema](#UploadSchema) ID for the record.
     schemaRevision:
         type: integer
+        readOnly: true
         format: int64
         description: |
             [UploadSchema](#UploadSchema) revision for the record.
     studyId:
         type: string
         description: Study that this record lives in.
+        readOnly: true
     uploadDate:
         type: string
         format: date
+        readOnly: true
         description: |
             Calendar date in YYYY-MM-DD format representing when the server received the upload, using the server's local time zone (US Pacific timezone).
     uploadId:
         type: string
+        readOnly: true
         description: The upload GUID of the upload this record is processed from.
     uploadedOn:
         type: string
+        readOnly: true
         format: date-time
         description: The date and time of the upload.
     userMetadata:
         type: object
+        readOnly: true
         description: |
             JSON map with key value pairs representing metadata for this health data record, as submitted by the app. This corresponds with the uploadMetadataFieldDefinitions configured in the study.
     userSharingScope:
         type: string
+        readOnly: true
         description: The user's sharing scope at the time of this upload's submission.
         $ref: ./enums/sharing_scope.yml
     userExternalId:
         type: string
+        readOnly: true
         description: The user's external ID at the time of this upload's submission.
     userDataGroups:
         type: array
+        readOnly: true
         description: The user's data groups at the time of this upload's submission.
         items:
             type: string
     userSubstudyMemberships:
         type: object
+        readOnly: true
         description: |
             A map where the keys are the substudy IDs assigned to the user at the time that user generated this 
             health data, and the values are the external IDs that were assigned to the user for each substudy (if no external ID was assigned, the value will be an empty string).
@@ -82,14 +101,17 @@ properties:
             type: string
     validationErrors:
         type: string
+        readOnly: true
         description: Error messages related to upload validation. Only generated if UploadValidationStrictness is set to REPORT.
     version:
         type: integer
+        readOnly: true
         format: int64
         description: |
             A version number issued for optimistic locking of record updates. Should not be set when creating a new health data record. When updating a record retrieved from the API, the object will have the version attribute and this must match the last value issued by the service or an update will fail.
     synapseExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/invalid_entity.yml
+++ b/rest-api/src/main/resources/definitions/invalid_entity.yml
@@ -5,9 +5,11 @@ readOnly: true
 properties:
     message:
         type: string
+        readOnly: true
         description: A message that will include all validation error messages for this object.
     errors:
         type: object
+        readOnly: true
         description: |
             Errors broken down by the part of the JSON payload that generated them. The keys are "paths" representing fragments of the JSON (expressed in JavaScript object/array notation), and the values are string arrays of one or more errors for that element of the JSON. An example makes this clearer:
 

--- a/rest-api/src/main/resources/definitions/paged_resources/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/account_summary.yml
@@ -8,5 +8,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../account_summary.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/activity.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../scheduled_activity.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/activity_event.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/activity_event.yml
@@ -1,13 +1,12 @@
 type: object
 readOnly: true
-required:
-    - items
-properties:
-    items:
-        type: array
+allOf:
+    - $ref: ./resource_list.yml
+    - required:
+        - items
+    - properties:
         items:
-            $ref: ../activity_event.yml
-    type:
-        type: string
-        readOnly: true
-        description: "ResourceList"
+            type: array
+            readOnly: true
+            items:
+                $ref: ../activity_event.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/app_config.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/app_config.yml
@@ -1,13 +1,12 @@
 type: object
 readOnly: true
-required:
-    - items
-properties:
-    items:
-        type: array
+allOf:
+    - $ref: ./resource_list.yml
+    - required:
+        - items
+    - properties:
         items:
-            $ref: ../app_config.yml
-    type:
-        type: string
-        readOnly: true
-        description: "ResourceList"
+            type: array
+            readOnly: true
+            items:
+                $ref: ../app_config.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/app_config_element.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/app_config_element.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../app_config_element.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/compound_activity_definition.yml
@@ -7,6 +7,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../compound_activity_definition.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/external_identifier.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/external_identifier.yml
@@ -7,5 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../external_identifier.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_paged_resource_list.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_paged_resource_list.yml
@@ -6,13 +6,16 @@ description: |
 properties:
     requestParams:
         $ref: ../request_params.yml
+        readOnly: true
     nextPageOffsetKey:
         type: string
+        readOnly: true
         description: |
             The offsetKey to be provided in the next request to get the next page of 
             resources.
     hasNext:
         type: boolean
+        readOnly: true
         description: true if there is a further page of resources, false otherwise.
     type:
         type: string

--- a/rest-api/src/main/resources/definitions/paged_resources/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/health_data_record.yml
@@ -9,6 +9,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../health_data_record.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/notification_registration.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/notification_registration.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../notification_registration.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/notification_topic.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/notification_topic.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../notification_topic.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/paged_resource_list.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/paged_resource_list.yml
@@ -2,6 +2,7 @@ type: object
 properties:
     requestParams:
         $ref: ../request_params.yml
+        readOnly: true
     total:
         type: integer
         readOnly: true

--- a/rest-api/src/main/resources/definitions/paged_resources/paged_string.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/paged_string.yml
@@ -7,5 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 type: string

--- a/rest-api/src/main/resources/definitions/paged_resources/report_data.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/report_data.yml
@@ -7,6 +7,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../report_data.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/report_index.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/report_index.yml
@@ -7,6 +7,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../report_index.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/resource_list.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/resource_list.yml
@@ -7,6 +7,7 @@ description: |
 properties:
     requestParams:
         $ref: ../request_params.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/paged_resources/schedule.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/schedule.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../schedule.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/schedule_plan.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/schedule_plan.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../schedule_plan.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../scheduled_activity.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity_v4.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity_v4.yml
@@ -9,6 +9,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../scheduled_activity.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/shared_module_metadata.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/shared_module_metadata.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../shared_module_metadata.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/string.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/string.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 type: string
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/study.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/study.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../study.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/study_consent.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/study_consent.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../study_consent.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/subpopulation.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/subpopulation.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../subpopulation.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/subscription_status.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/subscription_status.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../subscription_status.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/substudy.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/substudy.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../substudy.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/survey.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/survey.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../survey.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/upload.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/upload.yml
@@ -7,5 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../upload.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/upload_schema.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/upload_schema.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../upload_schema.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/request_info.yml
+++ b/rest-api/src/main/resources/definitions/request_info.yml
@@ -17,48 +17,57 @@ required:
 properties:
     userId:
         type: string
+        readOnly: true
         description: The user's account ID.
     clientInfo:
         $ref: ./client_info.yml
+        readOnly: true
         description: |
             The `User-Agent` string from the last request as parsed for the purpose of applying filtering criteria.
     userAgent:
         type: string
+        readOnly: true
         description: |
             The `User-Agent` header exactly as it was sent to the server, whether it is parseable by the Bridge server or not. 
     languages:
         type: array
+        readOnly: true
         description: |
             The language or languages sent in the user's `Accept-Language` header and persisted as part of the participant's account configuration, as they were set at the time of the last request.
         items:
             type: string
     userDataGroups:
         type: array
+        readOnly: true
         description: The data groups assigned to this participant at the time of the last request.
         items:
             type: string
     activitiesAccessedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The last recorded time the participant's application requested scheduled activities from the server.
     signedInOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The last recorded time the participant signed in to the server.
     uploadedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The last recorded time the participant started an upload to the server.
     timeZone:
         type: string
+        readOnly: true
         description: The user's time zone at the time of the last request.
     studyIdentifier:
         $ref: ./study_identifier.yml
     type:
         type: string
         readOnly: true
-        description: "ClientInfo"
+        description: "RequestInfo"
     

--- a/rest-api/src/main/resources/definitions/study_identifier.yml
+++ b/rest-api/src/main/resources/definitions/study_identifier.yml
@@ -5,6 +5,7 @@ required:
 properties:
     identifier:
         type: string
+        readOnly: true
         description: The study's identifier (unique to the study).
     type:
         type: string

--- a/rest-api/src/main/resources/definitions/upload.yml
+++ b/rest-api/src/main/resources/definitions/upload.yml
@@ -9,49 +9,61 @@ required:
 properties:
     uploadId:
         type: string
+        readOnly: true
         description: The GUID assigned to this upoad.
     schemaId:
         type: string
+        readOnly: true
         description: The ID of the schema for this upload.
     schemaRevision:
         type: integer
+        readOnly: true
         format: int64
         description: The revision for the schema of this upload.
     recordId:
         type: string
+        readOnly: true
         description: The record ID of the upload in Synapse.
     healthData:
         $ref: ./health_data_record.yml
+        readOnly: true
     contentLength:
         type: integer
+        readOnly: true
         format: int64
         description: |
             The size of the object in bytes. A standard HTTP header. For more information, go to [http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13)
     status:
         $ref: ./enums/upload_status.yml
+        readOnly: true
     requestedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The date and time (ISO 8601 format) that the client requested an URL to make an upload to the server.
     completedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The date and time (ISO 8601 format) that the upload was completed.
     completedBy:
         type: string
+        readOnly: true
         description: |
             Currently the API has an endpoint for the client to call and mark an upload completed. However, there is also a process that detects uploads to S3 and marks the uploads complete. This field indicates which client completed the upload.
         enum: [app, s3_worker]
     validationMessageList:
         type: array
+        readOnly: true
         description: |
             An array of error messages if this upload did not pass validation.
         items:
             type: string
     healthRecordExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/upload_session.yml
+++ b/rest-api/src/main/resources/definitions/upload_session.yml
@@ -6,14 +6,17 @@ required:
 properties:
     id:
         type: string
+        readOnly: true
         description: |
             The upload ID. The client needs to use this ID to call Bridge when the upload is complete.
     url:
         type: string
+        readOnly: true
         description: |
             A pre-signed URL for doing a PUT upload of the data. The URL will remain valid for 24 hours once created on the Bridge side.
     expires:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The ISO 8601 date and time stamp at which this session will expire.

--- a/rest-api/src/main/resources/definitions/upload_validation_status.yml
+++ b/rest-api/src/main/resources/definitions/upload_validation_status.yml
@@ -5,17 +5,21 @@ required:
 properties:
     id:
         type: string
+        readOnly: true
         description: The identifier for this upload.
     messageList:
         type: array
+        readOnly: true
         description: |
             An array of error messages if failures occurred during validation.
         items:
             type: string
     status:
         $ref: ./enums/upload_status.yml
+        readOnly: true
     record:
         $ref: ./health_data_record.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/user_consent_history.yml
+++ b/rest-api/src/main/resources/definitions/user_consent_history.yml
@@ -5,35 +5,44 @@ type: object
 properties:
     subpopulationGuid:
         type: string
+        readOnly: true
         description: The consent group that the participant agreed to participate in.
     consentCreatedOn:
         type: string
+        readOnly: true
         format: date-time
         description: ISO 8601 date and time that the consent was created on.
     name:
         type: string
+        readOnly: true
         description: Full name as entered by the participant.
     birthdate:
         type: string
+        readOnly: true
         format: date
         description: ISO 8601 date string (e.g. "YYYY-MM-DD").
     imageData:
         type: string
+        readOnly: true
         description: The signature image in a base 64 encoding.
     imageMimeType:
         type: string
+        readOnly: true
         description: The IANA mime type indicator for the image (e.g. "image/png").
     signedOn:
         type: string
+        readOnly: true
         format: date-time
         description: ISO 8601 date and time that the consent was signed by the user.
     withdrewOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             ISO 8601 date and time that the user withdrew the consent, if the user withdrew from the study (note that later consent records may re-enroll the user in the study; nothing prevents users from joining and quitting the study multiple times).
     hasSignedActiveConsent:
         type: boolean
+        readOnly: true
         description: |
             True if the user signed the most recently published version of the consent, false otherwise.
     type:

--- a/rest-api/src/main/resources/definitions/user_session_info.yml
+++ b/rest-api/src/main/resources/definitions/user_session_info.yml
@@ -1,38 +1,134 @@
 readOnly: true
 allOf:
-    - $ref: ./abstract_study_participant.yml
     - description: |
-        Information about the user and their session.
+        Information about the user and their session. This information cannot be updated; to update a user's record, use the StudyParticipant record and APIs.
     - type: object
     - properties:
+        firstName:
+            type: string
+            readOnly: true
+            description: First name (given name) of the user.
+        lastName:
+            type: string
+            readOnly: true
+            description: Last name (family name) of the user.
+        externalId:
+            type: string
+            readOnly: true
+            description: |
+                An externally-assignable identifier a research partner can use to re-identify a user's data in the exported data set (this must be provided by the application, it is not created by Bridge). It is a string that can be set or updated to any value without constraints, unless Bridge is configured to manage the study's external IDs. Then the ID must be submitted on sign up, and cannot be modified afterward.
+        id:
+            type: string
+            readOnly: true
+            description: |
+                An ID assigned to this account by Bridge system. This ID is exposed in the API and is different from the health code assigned to the user's anonymized data. Bridge never exports this ID along with the health code from Bridge.  
+        notifyByEmail:
+            type: boolean
+            readOnly: true
+            default: true
+            description: |
+                True if the user has consented to be contacted via email outside the application, false otherwise.
+        attributes:
+            type: object
+            readOnly: true
+            additionalProperties:
+                type: string
+            description: |
+                A map of user profile attributes that have been set for this user (the attributes themselves must be specified in the study's configuration, and the values are stored encrypted in case they capture personally-identifying information).
+        sharingScope:
+            $ref: ./enums/sharing_scope.yml
+            readOnly: true
+        createdOn:
+            type: string
+            format: date-time
+            readOnly: true
+            description: The date and time the account was created.
+        emailVerified:
+            type: boolean
+            readOnly: true
+            description: Has the user verified that they have control of this email address?
+        phoneVerified:
+            type: boolean
+            readOnly: true
+            description: Has the user verified that they have control of this phone number?
+        status:
+            $ref: ./enums/account_status.yml
+            readOnly: true
+        roles:
+            type: array
+            readOnly: true
+            items:
+                $ref: ./enums/role.yml
+        dataGroups:
+            type: array
+            readOnly: true
+            description: |
+                The data groups set for this user. Data groups must be strings that are defined in the list of all valid data groups for the study, as part of the study object. 
+            items:
+                type: string
+        clientData:
+            type: object
+            readOnly: true
+            description: |
+                Client data for a user should be in a syntactically valid JSON format. It will be returned as is to the client (as JSON).
+            additionalProperties: true
+        languages:
+            type: array
+            readOnly: true
+            description: |
+                Two letter language codes to assign to this user (these are initially retrieved from the user's `Accept-Language` header and then persisted as part of account configuration). 
+            items:
+                type: string
+        substudyIds:
+            type: array
+            readOnly: true
+            description: The substudies this participant is associated to.
+            items:
+                type: string
+        externalIds:
+            type: object
+            readOnly: true
+            description: The exernal IDs this participant is associated to, mapped to the substudy that issued the external ID. Typically a user signs up with the external ID, and is assigned to that substudy as a result.
+            additionalProperties:
+                type: string
         authenticated:
             type: boolean
+            readOnly: true
             description: Is the user currently authenticated?
         sessionToken:
             type: string
+            readOnly: true
             description: The session token that must be returned to the server to access services requiring authentication.
         reauthToken:
             type: string
+            readOnly: true
             description: |
                 A token, supplied when a new session is returned, that can be used to refresh the session at a later time. The API to reauthenticate with the token will refresh your session token and reset the session's timeout value. The reauthentication token can only be used one time. 
         environment:
             $ref: ./enums/environment.yml
+            readOnly: true
         email:
             type: string
+            readOnly: true
             description: The user's email.
         phone:
             $ref: ./phone.yml
+            readOnly: true
         dataSharing:
             type: boolean
+            readOnly: true
             description: True if the sharing scope is anything other than "no_sharing".
         signedMostRecentConsent:
             type: boolean
+            readOnly: true
             description: True if all *required* consents have been signed and the versions signed are the most up-to-date versions of those consents.
         consented:
             type: boolean
+            readOnly: true
             description: True if all required consents have been signed.
         consentStatuses:
             type: object
+            readOnly: true
             description: |
                 A mapping from a subpopulation GUID to information about the participant's consent status in that subpopulation (whether consented or not). Only the subpopulations that currently apply to this user will have a ConsentStatus object in the map.
             additionalProperties:

--- a/rest-api/src/main/resources/paths/activityevents/v1_activityevents.yml
+++ b/rest-api/src/main/resources/paths/activityevents/v1_activityevents.yml
@@ -17,7 +17,7 @@ post:
         - ActivityEvents
         - _For Consented Users
     parameters:
-        - name: body
+        - name: CustomActivityEventRequest
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/notifications/v3_notifications.yml
+++ b/rest-api/src/main/resources/paths/notifications/v3_notifications.yml
@@ -34,7 +34,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: NotificationRegistration
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/notifications/v3_notifications_guid.yml
+++ b/rest-api/src/main/resources/paths/notifications/v3_notifications_guid.yml
@@ -35,7 +35,7 @@ post:
         -   BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: NotificationRegistration
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/notifications/v3_notifications_guid_subscriptions.yml
+++ b/rest-api/src/main/resources/paths/notifications/v3_notifications_guid_subscriptions.yml
@@ -34,7 +34,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: SubscriptionRequest
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/oauth/v3_oauth_vendorId.yml
+++ b/rest-api/src/main/resources/paths/oauth/v3_oauth_vendorId.yml
@@ -13,7 +13,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/vendorId
-        - name: body
+        - name: OAuthAuthorizationToken
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/participants/v3_participants_userId_sendNotification.yml
+++ b/rest-api/src/main/resources/paths/participants/v3_participants_userId_sendNotification.yml
@@ -13,7 +13,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/userId
-        - name: body
+        - name: NotificationMessage
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/reports/v4_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/reports/v4_reports_identifier.yml
@@ -30,7 +30,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/identifier
-        - name: body
+        - name: ReportData
           description: Report data
           required: true
           in: body

--- a/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans.yml
+++ b/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans.yml
@@ -27,7 +27,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: SchedulePlan
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans_schedulePlanGuid.yml
+++ b/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans_schedulePlanGuid.yml
@@ -28,7 +28,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/schedulePlanGuid
-        - name: body
+        - name: SchedulePlan
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies.yml
@@ -31,7 +31,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: Study
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_init.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_init.yml
@@ -8,7 +8,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: StudyAndUsers
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_self.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_self.yml
@@ -29,7 +29,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: Study
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_self_synapseProject.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_self_synapseProject.yml
@@ -9,7 +9,7 @@ post:
     security:
         - BridgeSecurity: []
     parameters:
-        - name: body
+        - name: String[]
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId.yml
@@ -25,7 +25,7 @@ post:
         -   BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
-        - name: body
+        - name: Study
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId_participants_userId_sendSmsMessage.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId_participants_userId_sendSmsMessage.yml
@@ -10,7 +10,7 @@ post:
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
         - $ref: ../../index.yml#/parameters/userId
-        - name: body
+        - name: SmsTemplate
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId_reports_identifier.yml
@@ -29,7 +29,7 @@ post:
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
         - $ref: ../../index.yml#/parameters/identifier
-        - name: body
+        - name: ReportData
           description: Report data
           required: true
           in: body

--- a/rest-api/src/main/resources/paths/subpopulations/v3_subpopulations_subpopulationGuid_consents_signature.yml
+++ b/rest-api/src/main/resources/paths/subpopulations/v3_subpopulations_subpopulationGuid_consents_signature.yml
@@ -33,7 +33,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/subpopulationGuid
-        - name: body
+        - name: ConsentSignature
           description: A consent signature
           required: true
           in: body

--- a/rest-api/src/main/resources/paths/topics/v3_topics.yml
+++ b/rest-api/src/main/resources/paths/topics/v3_topics.yml
@@ -33,7 +33,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: NotificationTopic
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/topics/v3_topics_guid.yml
+++ b/rest-api/src/main/resources/paths/topics/v3_topics_guid.yml
@@ -27,7 +27,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: NotificationTopic
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/topics/v3_topics_guid_sendNotification.yml
+++ b/rest-api/src/main/resources/paths/topics/v3_topics_guid_sendNotification.yml
@@ -8,7 +8,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: NotificationMessage
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/users/v4_users_self_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/users/v4_users_self_reports_identifier.yml
@@ -36,7 +36,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/identifier
-        - name: body
+        - name: ReportData
           required: true
           in: body
           schema:

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.17.1</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/AuthenticationHandlerTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/AuthenticationHandlerTest.java
@@ -66,7 +66,8 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void interceptRequiringAuthAddsHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(chain.request()).thenReturn(request);
@@ -88,7 +89,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void interceptRequiringAuthAddsHeaderToChangeStudy() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(chain.request()).thenReturn(request);
@@ -107,7 +109,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void interceptNoAuthDoesNotAddHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(chain.request()).thenReturn(request);
@@ -122,7 +125,8 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void authenticateRequiringAuthAddsHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(response.request()).thenReturn(request);
@@ -141,7 +145,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void after401YouDoNotNeedSessionTokenToSignOut() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(response.request()).thenReturn(request);
@@ -158,7 +163,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void authenticateNoAuthDoesNotAddHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(response.request()).thenReturn(request);
@@ -174,7 +180,8 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void authenticateDoesNotCallReauthIfSessionHasChanged() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         when(userSessionInfoProvider.getSession()).thenReturn(session);
 

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.rest.Tests.setVariableValueInObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -199,25 +200,28 @@ public class RestUtilsTest {
     
     private ConsentStatus requiredConsent(String guid, boolean isConsented, boolean isRecent) {
         ConsentStatus status = new ConsentStatus();
-        status.setSubpopulationGuid(guid);
-        status.setConsented(isConsented);
-        status.setRequired(true);
-        status.setSignedMostRecentConsent(isRecent);
+        setVariableValueInObject(status, "subpopulationGuid", guid);
+        setVariableValueInObject(status, "consented", isConsented);
+        setVariableValueInObject(status, "required", true);
+        setVariableValueInObject(status, "signedMostRecentConsent", isRecent);
         return status;
     }
     
     private ConsentStatus optConsent(String guid, boolean isConsented, boolean isRecent) {
         ConsentStatus status = new ConsentStatus();
-        status.setSubpopulationGuid(guid);
-        status.setConsented(isConsented);
-        status.setRequired(false);
-        status.setSignedMostRecentConsent(isRecent);
+        setVariableValueInObject(status, "subpopulationGuid", guid);
+        setVariableValueInObject(status, "consented", isConsented);
+        setVariableValueInObject(status, "required", false);
+        setVariableValueInObject(status, "signedMostRecentConsent", isRecent);
         return status;
     }
     
     private UserSessionInfo session(Map<String,ConsentStatus> statuses) {
         UserSessionInfo session = new UserSessionInfo();
-        session.setConsentStatuses(statuses);
+        try {
+            Tests.setVariableValueInObject(session, "consentStatuses", statuses);    
+        } catch(Exception e) {
+        }
         return session;
     }
     

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/Tests.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/Tests.java
@@ -1,7 +1,31 @@
 package org.sagebionetworks.bridge.rest;
 
+import java.lang.reflect.Field;
+
 public class Tests {
     public static String unescapeJson(String json) {
         return json.replaceAll("'", "\"");
     }
+    public static void setVariableValueInObject(Object object, String variable, Object value) {
+        try {
+            Field field = getFieldByNameIncludingSuperclasses(variable, object.getClass());
+            field.setAccessible(true);
+            field.set(object, value);
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @SuppressWarnings("rawtypes")
+    private static Field getFieldByNameIncludingSuperclasses(String fieldName, Class clazz) {
+        Field retValue = null;
+        try {
+            retValue = clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            Class superclass = clazz.getSuperclass();
+            if ( superclass != null ) {
+                retValue = getFieldByNameIncludingSuperclasses( fieldName, superclass );
+            }
+        }
+        return retValue;
+    }    
 }

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/UserSessionInfoProviderTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/UserSessionInfoProviderTest.java
@@ -62,10 +62,10 @@ public class UserSessionInfoProviderTest {
     UserSessionInfoProvider provider;
     
     @Before
-    public void before() {
-        userSessionInfo = new UserSessionInfo()
-                .email("email@email.com")
-                .sessionToken("sessionToken");
+    public void before() throws Exception {
+        userSessionInfo = new UserSessionInfo();
+        Tests.setVariableValueInObject(userSessionInfo, "email", "email@email.com");
+        Tests.setVariableValueInObject(userSessionInfo, "sessionToken", "sessionToken");
         
         signIn = new SignIn().email("email@email.com").password("password").study("test-study");
         
@@ -104,7 +104,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
 
         provider.reauthenticate();
@@ -132,7 +132,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         provider.reauthenticate();
@@ -151,7 +151,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         provider.reauthenticate();
@@ -170,7 +170,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         provider.reauthenticate();
@@ -180,7 +180,7 @@ public class UserSessionInfoProviderTest {
     }
 
     @Test
-    public void reauthenticationFailsWithNoCredentialsAllowingSignIn() throws IOException {
+    public void reauthenticationFailsWithNoCredentialsAllowingSignIn() throws Exception {
 
         signIn = new SignIn().email("email@email.com").study("test-study");
 
@@ -192,7 +192,7 @@ public class UserSessionInfoProviderTest {
         AuthenticationFailedException e1 = new AuthenticationFailedException("message", "endpoint");
         doThrow(e1).when(call).execute();
 
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
 
         try {
@@ -219,7 +219,7 @@ public class UserSessionInfoProviderTest {
 
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         try {
@@ -246,20 +246,18 @@ public class UserSessionInfoProviderTest {
     }
 
     @Test
-    public void mergeReauthToken_A() {
+    public void mergeReauthToken_A() throws Exception {
         String reauthToken = "reauthToken";
         String sessionToken = "sessionToken";
-        UserSessionInfo userSessionInfo = new UserSessionInfo()
-                .sessionToken(sessionToken)
-                .reauthToken(reauthToken);
-
+        UserSessionInfo userSessionInfo = new UserSessionInfo();
+        Tests.setVariableValueInObject(userSessionInfo, "sessionToken", sessionToken);
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", reauthToken);
 
         String newSessionToken = "newSessionToken";
-        UserSessionInfo newUserSessionInfo = new UserSessionInfo()
-                .sessionToken(newSessionToken);
+        UserSessionInfo newUserSessionInfo = new UserSessionInfo();
+        Tests.setVariableValueInObject(newUserSessionInfo, "sessionToken", newSessionToken);
 
-
-        UserSessionInfoProvider.mergeReauthToken(userSessionInfo, newUserSessionInfo);
+        newUserSessionInfo = UserSessionInfoProvider.mergeReauthToken(userSessionInfo, newUserSessionInfo);
 
         assertEquals(sessionToken, userSessionInfo.getSessionToken()); // check old session token
         assertEquals(newSessionToken, newUserSessionInfo.getSessionToken()); // check this isn't the old session
@@ -267,11 +265,11 @@ public class UserSessionInfoProviderTest {
 
         String newReauthToken = "newReauthToken";
         String evenNewerSessionToken = "evenNewerSessionToken";
-        UserSessionInfo evenNewerSession = new UserSessionInfo()
-                .sessionToken(evenNewerSessionToken)
-                .reauthToken(newReauthToken);
+        UserSessionInfo evenNewerSession = new UserSessionInfo();
+        Tests.setVariableValueInObject(evenNewerSession, "sessionToken", evenNewerSessionToken);
+        Tests.setVariableValueInObject(evenNewerSession, "reauthToken", newReauthToken);
 
-        UserSessionInfoProvider.mergeReauthToken(newUserSessionInfo, evenNewerSession);
+        evenNewerSession = UserSessionInfoProvider.mergeReauthToken(newUserSessionInfo, evenNewerSession);
 
         assertEquals(evenNewerSessionToken, evenNewerSession.getSessionToken());
         assertEquals(newReauthToken, evenNewerSession.getReauthToken()); // check we wrote a new reauth token


### PR DESCRIPTION
One of the advantages of updating dependencies a month ago, is that the newer codegen libraries for Swagger respect more of the swagger definition file, and we can get closer to the ideal classes we would create if we were generating the SDK by hand. 

- many fields now correctly marked as readonly, which removes two methods, one fluent, one bean style for accessing those fields when they cannot be updated vis-a-vis the server;
- fixed some incorrectly typed files
- a list or two did not include the proper base list type, that should be fixed
- renamed body parameters to the model name, which is clearer in the api docs
- fixed tests to use reflection, and UserSessionInfoProvider to use serialization, to avoid having accessors that would be visible to SDK end users.