### PR TITLE
Improvements to semantics of required vs. nullable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.18.0</version>
+    <version>0.18.1</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.17.1</version>
+    <version>0.18.0</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.18.0</version>
+        <version>0.18.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.17.1</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/ab_test_group.yml
+++ b/rest-api/src/main/resources/definitions/ab_test_group.yml
@@ -1,8 +1,6 @@
 type: object
 description: |
-    A list of these groups define the way schedules are allocated in an ABTestScheduleStrategy 
-    (each schedule associated to a percentage). See [ABTestScheduleStrategy](#ABTestScheduleStrategy) 
-    for details. 
+    A list of these groups define the way schedules are allocated in an ABTestScheduleStrategy (each schedule associated to a percentage). See [ABTestScheduleStrategy](#ABTestScheduleStrategy) for details. 
 required:
     - percentage
     - schedule
@@ -10,10 +8,13 @@ properties:
     percentage:
         type: integer
         description: The percentage of users to assign to this schedule.
+        x-nullable: false
     schedule:
         description: The schedule to assign to these users.
         $ref: ./schedule.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ABTestGroup"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/ab_test_schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/ab_test_schedule_strategy.yml
@@ -1,12 +1,7 @@
 description: |
-    A strategy that divides users into groups according to a percentage scheme, assigning each 
-    group a different [Schedule](/#Schedule). The combined set of schedule groups should have 
-    percentages that add up to 100%. After the initial assignment, new users joining the study 
-    will be randomly assigned to one of the groups in proportion to their percentage 
-    representation in the study. 
+    A strategy that divides users into groups according to a percentage scheme, assigning each group a different [Schedule](/#Schedule). The combined set of schedule groups should have percentages that add up to 100%. After the initial assignment, new users joining the study will be randomly assigned to one of the groups in proportion to their percentage representation in the study. 
 
-    Note that this assignment is truly random, so in small populations the percentages may diverge 
-    from those specified in the schedule plan.
+    Note that this assignment is truly random, so in small populations the percentages may diverge from those specified in the schedule plan.
 allOf:
     - $ref: ./schedule_strategy.yml
     - type: object
@@ -17,3 +12,4 @@ allOf:
             type: array
             items:
                 $ref: ./ab_test_group.yml
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/ab_test_schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/ab_test_schedule_strategy.yml
@@ -13,3 +13,8 @@ allOf:
             items:
                 $ref: ./ab_test_group.yml
             x-nullable: false
+        type:
+            type: string
+            readOnly: true
+            description: "ABTestScheduleStrategy"
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -1,4 +1,5 @@
 type: object
+description: Common fields for the SignUp and StudyParticipant payloads. This is an abstract class that cannot be used directly through the API.
 required:
     - roles
     - dataGroups

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -1,9 +1,5 @@
 type: object
 description: Common fields for the SignUp and StudyParticipant payloads. This is an abstract class that cannot be used directly through the API.
-required:
-    - roles
-    - dataGroups
-    - languages
 properties:
     firstName:
         type: string
@@ -20,42 +16,52 @@ properties:
         readOnly: true
         description: |
             An ID assigned to this account by Bridge system. This ID is exposed in the API and is different from the health code assigned to the user's anonymized data. Bridge never exports this ID along with the health code from Bridge.  
+        x-nullable: false
     notifyByEmail:
         type: boolean
         default: true
         description: |
             True if the user has consented to be contacted via email outside the application, false otherwise.
+        x-nullable: false
     attributes:
         type: object
         additionalProperties:
             type: string
         description: |
             A map of user profile attributes that have been set for this user (the attributes themselves must be specified in the study's configuration, and the values are stored encrypted in case they capture personally-identifying information).
+        x-nullable: false
     sharingScope:
         $ref: ./enums/sharing_scope.yml
+        x-nullable: false
     createdOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time the account was created.
+        x-nullable: false
     emailVerified:
         type: boolean
         description: Has the user verified that they have control of this email address?
+        x-nullable: false
     phoneVerified:
         type: boolean
         description: Has the user verified that they have control of this phone number?
+        x-nullable: false
     status:
         $ref: ./enums/account_status.yml
+        x-nullable: false
     roles:
         type: array
         items:
             $ref: ./enums/role.yml
+        x-nullable: false
     dataGroups:
         type: array
         description: |
             The data groups set for this user. Data groups must be strings that are defined in the list of all valid data groups for the study, as part of the study object. 
         items:
             type: string
+        x-nullable: false
     clientData:
         type: object
         description: |
@@ -67,13 +73,16 @@ properties:
             Two letter language codes to assign to this user (these are initially retrieved from the user's `Accept-Language` header and then persisted as part of account configuration). 
         items:
             type: string
+        x-nullable: false
     substudyIds:
         type: array
         description: The substudies this participant is associated to.
         items:
             type: string
+        x-nullable: false
     externalIds:
         type: object
         description: The exernal IDs this participant is associated to, mapped to the substudy that issued the external ID. Typically a user signs up with the external ID, and is assigned to that substudy as a result.
         additionalProperties:
             type: string
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -22,24 +22,30 @@ properties:
         type: string
         readOnly: true
         description: An identifier assigned to this user, used to retrieve a study participant record.
+        x-nullable: false
     createdOn: 
         type: string
         format: date-time
         readOnly: true
         description: ISO 8601 date and time that the user account was created.
+        x-nullable: false
     status:
         $ref: ./enums/account_status.yml
         readOnly: true
+        x-nullable: false
     studyIdentifier:
         $ref: ./study_identifier.yml
         readOnly: true
+        x-nullable: false
     substudyIds:
         type: array
         readOnly: true
         description: The substudies this participant is associated to.
         items:
             type: string
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "AccountSummary"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -5,17 +5,22 @@ readOnly: true
 properties:
     firstName:
         type: string
+        readOnly: true
         description: First (given) name of user.
     lastName:
         type: string
+        readOnly: true
         description: Last (family) name of user.
     email:
         type: string
+        readOnly: true
         description: Email address of user.
     phone:
         $ref: ./phone.yml
+        readOnly: true
     id: 
         type: string
+        readOnly: true
         description: An identifier assigned to this user, used to retrieve a study participant record.
     createdOn: 
         type: string
@@ -24,10 +29,13 @@ properties:
         description: ISO 8601 date and time that the user account was created.
     status:
         $ref: ./enums/account_status.yml
+        readOnly: true
     studyIdentifier:
         $ref: ./study_identifier.yml
+        readOnly: true
     substudyIds:
         type: array
+        readOnly: true
         description: The substudies this participant is associated to.
         items:
             type: string

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -1,5 +1,5 @@
 description: |
-    Summary of a participant, used in APIs to search and retrieve participant accounts.  
+    Summary of a participant, used in APIs to search and retrieve participant accounts. This payload is returned from the API, but is never submitted to the API.
 type: object
 readOnly: true
 properties:

--- a/rest-api/src/main/resources/definitions/account_summary_search.yml
+++ b/rest-api/src/main/resources/definitions/account_summary_search.yml
@@ -1,5 +1,5 @@
 description: |
-    Search criteria to retrieve account summaries of study participants
+    Search criteria to retrieve account summaries of study participants. This payload is sent to the server but is never returned via the API.
 type: object
 properties:
     pageSize:
@@ -24,17 +24,14 @@ properties:
         type: array
         items:
             type: string
-        x-nullable: false
     noneOfGroups:
         description: return records that have none of these data groups
         type: array
         items:
             type: string
-        x-nullable: false
     language:
         description: return records that have this record as a declared language
         type: string
-        x-nullable: false
     startTime:
         description: return record created on or after this day
         type: string

--- a/rest-api/src/main/resources/definitions/account_summary_search.yml
+++ b/rest-api/src/main/resources/definitions/account_summary_search.yml
@@ -1,9 +1,6 @@
 description: |
     Search criteria to retrieve account summaries of study participants
 type: object
-required:
-    - allOfGroups
-    - noneOfGroups
 properties:
     pageSize:
         description: maximum number of records in each returned page
@@ -27,14 +24,17 @@ properties:
         type: array
         items:
             type: string
+        x-nullable: false
     noneOfGroups:
         description: return records that have none of these data groups
         type: array
         items:
             type: string
+        x-nullable: false
     language:
         description: return records that have this record as a declared language
         type: string
+        x-nullable: false
     startTime:
         description: return record created on or after this day
         type: string
@@ -47,3 +47,4 @@ properties:
         type: string
         readOnly: true
         description: "AccountSummarySearch"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/activity.yml
+++ b/rest-api/src/main/resources/definitions/activity.yml
@@ -11,6 +11,7 @@ properties:
     label:
         type: string
         description: A label to show the user for this activity.
+        x-nullable: false
     labelDetail:
         type: string
         description: |
@@ -18,6 +19,7 @@ properties:
             questions, or the average time it takes to complete the activity).
     guid:
         type: string
+        x-nullable: false
     compoundActivity:
         $ref: ./compound_activity.yml
     task:
@@ -26,7 +28,9 @@ properties:
         $ref: ./survey_reference.yml
     activityType:
         $ref: ./enums/activity_type.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Activity"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/activity_event.yml
+++ b/rest-api/src/main/resources/definitions/activity_event.yml
@@ -18,3 +18,8 @@ properties:
         format: date-time
         description: ISO 8601 date and time that the event occured
         x-nullable: false
+    type:
+        type: string
+        readOnly: true
+        description: "ActivityEvent"
+        x-nullable: false        

--- a/rest-api/src/main/resources/definitions/activity_event.yml
+++ b/rest-api/src/main/resources/definitions/activity_event.yml
@@ -3,10 +3,12 @@ description: |
 type: object
 required:
     - eventId
+    - timestamp
 properties:
     eventId:
         type: string
         description: event identifier
+        x-nullable: false
     answerValue:
         type: string
         description: answer value for a question event
@@ -15,3 +17,4 @@ properties:
         type: string
         format: date-time
         description: ISO 8601 date and time that the event occured
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/android_app_link.yml
+++ b/rest-api/src/main/resources/definitions/android_app_link.yml
@@ -6,13 +6,17 @@ required:
 properties:
     namespace:
         type: string
+        x-nullable: false
     package_name:
         type: string
+        x-nullable: false
     sha256_cert_fingerprints:
         type: array
         items:
             type: string
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "AndroidAppLink"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/app_config.yml
+++ b/rest-api/src/main/resources/definitions/app_config.yml
@@ -3,8 +3,6 @@ description: |
 type: object
 required:
     - label
-    - surveyReferences
-    - schemaReferences
 properties:
     label:
         type: string

--- a/rest-api/src/main/resources/definitions/app_config.yml
+++ b/rest-api/src/main/resources/definitions/app_config.yml
@@ -2,30 +2,37 @@ description: |
     An app configuration object.
 type: object
 required:
+    - label
     - surveyReferences
     - schemaReferences
 properties:
     label:
         type: string
+        x-nullable: false
     createdOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time the app config was created.
+        x-nullable: false
     modifiedOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time the app config was last modified.
+        x-nullable: false
     guid:
         type: string
+        x-nullable: false
     deleted:
         type: boolean
         description: Has this app config been logically deleted (an admin can restore it)?
+        x-nullable: false
     criteria:
         $ref: ./criteria.yml
         description: |
             Optional selection criteria that can be used to determine if an app should receive this configuration record or not. It is an error for a request to match more or less than one app config record. 
+        x-nullable: false
     clientData:
         type: object
         description: |
@@ -38,26 +45,32 @@ properties:
         type: array
         items:
             $ref: ./survey_reference.yml
+        x-nullable: false
     schemaReferences:
         type: array
         items:
             $ref: ./schema_reference.yml
+        x-nullable: false
     configReferences:
         type: array
         items:
             $ref: ./config_reference.yml
+        x-nullable: false
     configElements:
         type: object
         description: |
             A map of app config element IDs to the app config element JSON of a specific app config element revision (the revision given in the configReferences map).
         additionalProperties:
             type: object
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The optimistic locking version of the app config. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring. It can also serve as a key to determine if a local cache of `AppConfig` needs to be updated.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "AppConfig"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/app_config_element.yml
+++ b/rest-api/src/main/resources/definitions/app_config_element.yml
@@ -5,7 +5,6 @@ required:
     - id
     - data
     - revision
-    - version
 properties:
     id:
         type: string

--- a/rest-api/src/main/resources/definitions/app_config_element.yml
+++ b/rest-api/src/main/resources/definitions/app_config_element.yml
@@ -11,15 +11,18 @@ properties:
         type: string
         description: |
             The identifier for this app config element. All revisions of this element will have the same id.
+        x-nullable: false
     revision:
         type: integer
         format: int64
         description: |
             Revision number of the app config element, used to distinguish revisions of the element. Each revision will also have an optimistic locking `version` which should always be passed back as is when updating a specific revision of the element.
+        x-nullable: false
     deleted:
         type: boolean
         description: |
             Has this app config element been logically deleted (an admin can restore it)?
+        x-nullable: false
     data:
         type: object
         description: The JSON data of this element.
@@ -28,13 +31,21 @@ properties:
         format: date-time
         readOnly: true
         description: The date and time the app config was created.
+        x-nullable: false
     modifiedOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time the app config was last modified.
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The optimistic locking version of the app config element. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring. It can also serve as a key to determine if a local cache of this `AppConfigElement` revision needs to be updated.
+        x-nullable: false
+    type:
+        type: string
+        readOnly: true
+        description: "AppConfigElement"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/apple_app_link.yml
+++ b/rest-api/src/main/resources/definitions/apple_app_link.yml
@@ -5,11 +5,14 @@ required:
 properties:
     appID:
         type: string
+        x-nullable: false
     paths:
         type: array
         items:
             type: string
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "AppleAppLink"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/client_info.yml
+++ b/rest-api/src/main/resources/definitions/client_info.yml
@@ -30,3 +30,4 @@ properties:
         type: string
         readOnly: true
         description: "ClientInfo"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/cms_public_key.yml
+++ b/rest-api/src/main/resources/definitions/cms_public_key.yml
@@ -8,6 +8,7 @@ required:
 properties:
     publicKey:
         type: string
+        readOnly: true
         description: |
             Base 64 encoded version of the public key for CMS encryption of upload data.    
     type:

--- a/rest-api/src/main/resources/definitions/cms_public_key.yml
+++ b/rest-api/src/main/resources/definitions/cms_public_key.yml
@@ -7,8 +7,7 @@ properties:
     publicKey:
         type: string
         readOnly: true
-        description: |
-            Base 64 encoded version of the public key for CMS encryption of upload data.    
+        description: Base 64 encoded version of the public key for CMS encryption of upload data.    
         x-nullable: false
     type:
         type: string

--- a/rest-api/src/main/resources/definitions/cms_public_key.yml
+++ b/rest-api/src/main/resources/definitions/cms_public_key.yml
@@ -3,16 +3,16 @@ description: |
     study. Each study has a different CMS public key.
 type: object
 readOnly: true
-required:
-    - publicKey
 properties:
     publicKey:
         type: string
         readOnly: true
         description: |
             Base 64 encoded version of the public key for CMS encryption of upload data.    
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "CmsPublicKey"
+        x-nullable: false
 

--- a/rest-api/src/main/resources/definitions/compound_activity.yml
+++ b/rest-api/src/main/resources/definitions/compound_activity.yml
@@ -10,15 +10,20 @@ properties:
         type: array
         items:
             $ref: ./schema_reference.yml
+        x-nullable: false
     surveyList:
         type: array
         items:
             $ref: ./survey_reference.yml
+        x-nullable: false
     taskIdentifier:
         type: string
         description: |
             Task ID, used to uniquely identify the compound activity and to resolve the compound activity reference from the compound activity definition, where applicable.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "CompoundActivity"
+        x-nullable: false
+

--- a/rest-api/src/main/resources/definitions/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/compound_activity_definition.yml
@@ -26,4 +26,4 @@ properties:
     type:
         type: string
         readOnly: true
-        description: "CompoundActivity"
+        description: "CompoundActivityDefinition"

--- a/rest-api/src/main/resources/definitions/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/compound_activity_definition.yml
@@ -10,20 +10,25 @@ properties:
         type: array
         items:
             $ref: ./schema_reference.yml
+        x-nullable: false
     surveyList:
         type: array
         items:
             $ref: ./survey_reference.yml
+        x-nullable: false
     taskId:
         type: string
         description: |
             Task ID, used to uniquely identify the compound activity and to resolve the compound activity reference from the compound activity definition, where applicable.
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The optimistic locking version of the survey. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "CompoundActivityDefinition"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/config_reference.yml
+++ b/rest-api/src/main/resources/definitions/config_reference.yml
@@ -11,7 +11,3 @@ properties:
         type: integer
         format: int64
         description: Revision number
-    type:
-        type: string
-        readOnly: true
-        description: "ConfigReference"

--- a/rest-api/src/main/resources/definitions/config_reference.yml
+++ b/rest-api/src/main/resources/definitions/config_reference.yml
@@ -11,3 +11,7 @@ properties:
         type: integer
         format: int64
         description: Revision number
+    type:
+        type: string
+        readOnly: true
+        description: "ConfigReference"

--- a/rest-api/src/main/resources/definitions/config_reference.yml
+++ b/rest-api/src/main/resources/definitions/config_reference.yml
@@ -7,11 +7,14 @@ properties:
     id:
         type: string
         description: Schema ID
+        x-nullable: false
     revision:
         type: integer
         format: int64
         description: Revision number
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ConfigReference"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/consent_signature.yml
+++ b/rest-api/src/main/resources/definitions/consent_signature.yml
@@ -14,11 +14,11 @@ type: object
 required:
     - name
     - scope
-    - signedOn
 properties:
     name:
         type: string
         description: The participant's name.
+        x-nullable: false
     birthdate:
         type: string
         format: date
@@ -36,6 +36,7 @@ properties:
         format: date-time
         readOnly: true
         description: The date and time the referenced consent was signed and agreed to by the participant.
+        x-nullable: false
     withdrewOn:
         type: string
         format: date-time
@@ -43,8 +44,10 @@ properties:
         description: The date and time the participant withdrew consent (can be blank).
     scope:
         $ref: ./enums/sharing_scope.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ConsentSignature"
+        x-nullable: false
     

--- a/rest-api/src/main/resources/definitions/consent_status.yml
+++ b/rest-api/src/main/resources/definitions/consent_status.yml
@@ -1,7 +1,6 @@
 description: |
     A description of the participant's consent status in a particular subpopulation (consent group). This object is never used to update state on the server (all fields are read only). 
 type: object
-readOnly: true
 properties:
     name:
         type: string

--- a/rest-api/src/main/resources/definitions/consent_status.yml
+++ b/rest-api/src/main/resources/definitions/consent_status.yml
@@ -7,15 +7,18 @@ properties:
         type: string
         readOnly: true
         description: The name of the subpopulation.
+        x-nullable: false
     subpopulationGuid:
         type: string
         readOnly: true
         description: The GUID for the subpopulation of this consent.
+        x-nullable: false
     required:
         type: boolean
         readOnly: true
         description: |
             Is this consent required? If required, the user must consent to it before being given access to the server (until signed, a 412 response is returned for most participant endpoints).
+        x-nullable: false
     signedOn:
         type: string
         format: date-time
@@ -29,8 +32,10 @@ properties:
         type: boolean
         readOnly: true
         description: |
-            Was the consent to participate made against the most recently published version of this consent?
+            Was the consent to participate made against the most recently published version of this consent? If there's no signature this will be false (not null).
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ConsentStatus"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/consent_status.yml
+++ b/rest-api/src/main/resources/definitions/consent_status.yml
@@ -5,12 +5,15 @@ readOnly: true
 properties:
     name:
         type: string
+        readOnly: true
         description: The name of the subpopulation.
     subpopulationGuid:
         type: string
+        readOnly: true
         description: The GUID for the subpopulation of this consent.
     required:
         type: boolean
+        readOnly: true
         description: |
             Is this consent required? If required, the user must consent to it before being given access to the server (until signed, a 412 response is returned for most participant endpoints).
     signedOn:
@@ -20,9 +23,11 @@ properties:
         description: The date and time the referenced consent was signed and agreed to by the participant. If there is a signedOn value, consented will be equal to true.
     consented:
         type: boolean
+        readOnly: true
         description: Has the participant consented to this consent agreement? If the user has signed this consent, there should be a signedOn timestamp value.
     signedMostRecentConsent:
         type: boolean
+        readOnly: true
         description: |
             Was the consent to participate made against the most recently published version of this consent?
     type:

--- a/rest-api/src/main/resources/definitions/constraints/bloodpressure_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/bloodpressure_constraints.yml
@@ -2,8 +2,6 @@ description: |
     Systolic and diastolic systemic arterial pressure.
     
     **UI hints:** bloodpressure
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/constraints.yml
@@ -1,10 +1,11 @@
 type: object
 discriminator: type
 required:
-    - type
+    - dataType
 properties:
     dataType:
         $ref: ../enums/data_type.yml
     type:
         type: string
+        x-nullable: false
         readOnly: true

--- a/rest-api/src/main/resources/definitions/constraints/date_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/date_constraints.yml
@@ -2,8 +2,6 @@ description: |
     A date without a time value (e.g. "2016-07-28").
 
     **UI hints:** datepicker.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:
@@ -15,13 +13,9 @@ allOf:
             type: string
             format: date
             description: |
-                ISO 8601 date value that is the earliest value that may be set for this question. 
-                If allowFuture is false, that constraint should also be applied regardless of 
-                earliest/latestValue constraints.
+                ISO 8601 date value that is the earliest value that may be set for this question. If allowFuture is false, that constraint should also be applied regardless of earliest/latestValue constraints.
         latestValue:
             type: string
             format: date
             description: |
-                ISO 8601 date value that is the earliest value that may be set for this question. 
-                If allowFuture is false, that constraint should also be applied regardless of  
-                earliest/latestValue constraints.
+                ISO 8601 date value that is the earliest value that may be set for this question. If allowFuture is false, that constraint should also be applied regardless of earliest/latestValue constraints.

--- a/rest-api/src/main/resources/definitions/constraints/datetime_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/datetime_constraints.yml
@@ -1,7 +1,5 @@
 description: |
     **UI hints:** datetimepicker.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/decimal_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/decimal_constraints.yml
@@ -2,8 +2,6 @@ description: |
     A floating point value.
 
     **UI hints:** numberfield, slider, select.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/duration_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/duration_constraints.yml
@@ -6,7 +6,6 @@ description: |
     **UI hints:** numberfield, slider, select.
 required:
     - unit
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/height_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/height_constraints.yml
@@ -2,8 +2,6 @@ description: |
     A floating point value.
 
     **UI hints:** weight.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/integer_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/integer_constraints.yml
@@ -3,8 +3,6 @@ description: |
     a measure or a duration (e.g. "3 hours", or "180 pounds").
 
     **UI hints:** numberfield, slider, select.
-required: 
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/multivalue_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/multivalue_constraints.yml
@@ -10,7 +10,6 @@ description: |
     |radiobutton, select, slider|`allowMultiple` = false, `allowOther` = false|
 required:
     - enumeration
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:
@@ -27,5 +26,6 @@ allOf:
         enumeration:
             type: array
             description: The options presented for selection to the user.
+            x-nullable: false
             items:
                 $ref: ../survey_question_option.yml

--- a/rest-api/src/main/resources/definitions/constraints/postalcode_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/postalcode_constraints.yml
@@ -4,14 +4,10 @@ description: |
     * Canada (CA) - The first three characters of a Canadian postal code describe a sorting area of about 7,000 households. No specific guidance is given, but collecting the first 3 characters has been deemed reasonable. 
     * United States (US) - collect only the first three digits of a zip code. Some 3 digit codes describe areas of 20,000 or less people; for these exceptional codes, substitute the value "000" instead before submitting to the server. If the survey constraints indicate that a US zip code is required, the `sparseZipCodePrefixes` array will be included in the constraint, with a list of these special partial zip codes. They are provided by the server so they can be updated based on new census information without having to update the survey or the client.
 
-    One way to protect the anonymity of the user is to limit the combination of partially identifying 
-    information that is asked for in a survey. For example do no ask for a specific birthdate in a survey 
-    where the information will be submitted to the server. This makes a partial postal code significantly 
-    less useful for reidentification.
+    One way to protect the anonymity of the user is to limit the combination of partially identifying information that is asked for in a survey. For example do no ask for a specific birthdate in a survey where the information will be submitted to the server. This makes a partial postal code significantly less useful for reidentification.
 
     **UI hints:** postalcode.
 required:
-    - dataType
     - countryCode
 allOf:
     - $ref: ./constraints.yml
@@ -20,8 +16,9 @@ allOf:
             $ref: ../enums/country_code.yml
         sparseZipCodePrefixes:
             type: array
+            readOnly: true
+            x-nullable: false
             items:
                 type: string
-            readOnly: true
             description: |
                 Some 3 digit codes describe areas of 20,000 or less people; for these exceptional codes, which can more easily be used to reidentify participants, substitute the value "000" instead before submitting the survey answer to the server. If the survey constraints indicate that a US zip code is required, the `sparseZipCodePrefixes` array will be included in the constraint, with a list of these special partial zip codes.

--- a/rest-api/src/main/resources/definitions/constraints/string_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/string_constraints.yml
@@ -2,8 +2,6 @@ description: |
     A string answer. 
 
     **UI hints:** texfield, multilinetext.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/time_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/time_constraints.yml
@@ -4,7 +4,5 @@ description: |
     of where the user is, e.g. "I take my medications at 3:00pm every day, whether I'm in Chicago or Tokyo."
 
     **UI hints:** timepicker.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml

--- a/rest-api/src/main/resources/definitions/constraints/weight_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/weight_constraints.yml
@@ -2,8 +2,6 @@ description: |
     A floating point value.
 
     **UI hints:** weight.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/constraints/yearmonth_constraints.yml
+++ b/rest-api/src/main/resources/definitions/constraints/yearmonth_constraints.yml
@@ -2,8 +2,6 @@ description: |
     A year and month without a date or time (e.g. "2016-07").
 
     **UI hints:** yearmonth.
-required:
-    - dataType
 allOf:
     - $ref: ./constraints.yml
     - properties:

--- a/rest-api/src/main/resources/definitions/criteria.yml
+++ b/rest-api/src/main/resources/definitions/criteria.yml
@@ -1,13 +1,6 @@
 type: object
 description: |
     Some objects, like Subpopulations and the schedules in a CriteriaScheduleStrategy, are matched against user criteria in order to return the correct object. The criteria against which user information will be matched are described in the Criteria object. See [Customizing Content for Participants](/articles/filtering.html) for a fuller explanation. 
-required:
-    - allOfGroups
-    - noneOfGroups
-    - allOfSubstudyIds
-    - noneOfSubstudyIds
-    - minAppVersions
-    - maxAppVersions
 properties:
     language:
         type: string
@@ -18,34 +11,41 @@ properties:
         description: One or more data groups; the user must have all these data groups to match.
         items:
             type: string
+        x-nullable: false
     noneOfGroups:
         type: array
         description: One or more data groups; the user must have none of these data groups to match.
         items:
             type: string
+        x-nullable: false
     allOfSubstudyIds:
         type: array
         description: One or more substudy IDs; the user must be assigned to all these substudies to match.
         items:
             type: string
+        x-nullable: false
     noneOfSubstudyIds:
         type: array
         description: One or more substudy IDs; the user cannot be assigned to any of these substudies for the associated object to match.
         items:
             type: string
+        x-nullable: false
     minAppVersions:
         type: object
         description: |
             A map of operating system names to minimum app versions. The user must send a `User-Agent` header in a prescribed format, that declares the app version to be equal to or greater than this version number, in order to match.
         additionalProperties:
             type: integer
+        x-nullable: false
     maxAppVersions:
         type: object
         description: |
             A map of operating system names to minimum app versions. The user must send a `User-Agent` header in a prescribed format, that declares the app version to be equal to or less than this version number, in order to match.
         additionalProperties:
             type: integer
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Criteria"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/criteria_schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/criteria_schedule_strategy.yml
@@ -12,3 +12,8 @@ allOf:
             items:
                 $ref: ./schedule_criteria.yml
             x-nullable: false
+        type:
+            type: string
+            readOnly: true
+            description: "CriteriaScheduleStrategy"
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/criteria_schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/criteria_schedule_strategy.yml
@@ -11,3 +11,4 @@ allOf:
             description: The list of schedules and their criteria.
             items:
                 $ref: ./schedule_criteria.yml
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/custom_activity_event_request.yml
+++ b/rest-api/src/main/resources/definitions/custom_activity_event_request.yml
@@ -7,9 +7,13 @@ properties:
     eventKey:
         type: string
         description: identifier for the custom event
-        x-nullable:  false
     timestamp:
         type: string
         format: date-time
         description:  ISO 8601 date and time to record for event
-        x-nullable:  false
+    type:
+        type: string
+        readOnly: true
+        description: "CustomActivityEventRequest"
+        x-nullable: false
+    

--- a/rest-api/src/main/resources/definitions/custom_activity_event_request.yml
+++ b/rest-api/src/main/resources/definitions/custom_activity_event_request.yml
@@ -2,11 +2,14 @@ description: Request object for creating a Custom Activity Event.
 type: object
 required:
     - eventKey
+    - timestamp
 properties:
     eventKey:
         type: string
         description: identifier for the custom event
+        x-nullable:  false
     timestamp:
         type: string
         format: date-time
         description:  ISO 8601 date and time to record for event
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/data_groups.yml
+++ b/rest-api/src/main/resources/definitions/data_groups.yml
@@ -7,7 +7,9 @@ properties:
         type: array
         items:
             type: string
+        x-nullable:  false
     type:
         type: string
         readOnly: true
         description: "DataGroups"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/email_signin.yml
+++ b/rest-api/src/main/resources/definitions/email_signin.yml
@@ -20,3 +20,4 @@ properties:
         type: string
         readOnly: true
         description: "EmailSignIn"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/email_signin_request.yml
+++ b/rest-api/src/main/resources/definitions/email_signin_request.yml
@@ -15,3 +15,4 @@ properties:
         type: string
         readOnly: true
         description: "EmailSignInRequest"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/email_template.yml
+++ b/rest-api/src/main/resources/definitions/email_template.yml
@@ -77,12 +77,16 @@ properties:
     subject:
         type: string
         description: The subject line of the email message (no markup allowed)
+        x-nullable:  false
     mimeType:
         $ref: ./enums/mime_type.yml
+        x-nullable:  false
     body:
         type: string
         description: The body text of the email message (can be text or HTML, but the mimeType must be set appropriately)
+        x-nullable:  false
     type:
         type: string
         readOnly: true
         description: "EmailTemplate"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/email_verification_status.yml
+++ b/rest-api/src/main/resources/definitions/email_verification_status.yml
@@ -1,13 +1,13 @@
 description: |
     The status of the email address that will be used to send consents to users. The consents are sent on behalf of the study using the study's support email address, and our email provider (Amazon's SES) requires that the address holder confirm this is an allowed use of the address. 
 type: object
-required:
-    - status
 properties:
     status:
         $ref: ./enums/account_status.yml
         readOnly: true
+        x-nullable:  false
     type:
         type: string
         readOnly: true
         description: "EmailVerificationStatus"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/email_verification_status.yml
+++ b/rest-api/src/main/resources/definitions/email_verification_status.yml
@@ -6,6 +6,7 @@ required:
 properties:
     status:
         $ref: ./enums/account_status.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/external_identifier.yml
+++ b/rest-api/src/main/resources/definitions/external_identifier.yml
@@ -3,18 +3,23 @@ description: |
 type: object
 required:
     - identifier
+    - substudyId
 properties:
     identifier:
         type: string
         description: The external identifier.
+        x-nullable:  false
     substudyId:
         type: string
         description: The substudy ID of the associated substudy for external ID
+        x-nullable:  false
     assigned:
         type: boolean
         readOnly: true
         description: If true, the identifier has been assigned to an account, otherwise false.
+        x-nullable:  false
     type:
         type: string
         readOnly: true
         description: "ExternalIdentifier"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/generated_password.yml
+++ b/rest-api/src/main/resources/definitions/generated_password.yml
@@ -1,24 +1,24 @@
 type: object
-required:
-    - externalId
-    - userId
-    - password
 properties:
     externalId:
         type: string
         readOnly: true
         description: The external ID for which a password is being generated.
+        x-nullable:  false
     userId:
         type: string
         readOnly: true
         description: |
             The user ID of the account for which a password has been generated. The user ID will be returned whether this call created an account for the external ID, or whether the account already existed.
+        x-nullable:  false
     password:
         type: string
         readOnly: true
         description: |
             A randomly generated password. This password will pass your study's password validation constraints, unless you change these after creating the password. **This password should not be generated off the device this study participant will use to conduct the study.**
+        x-nullable:  false
     type:
         type: string
         readOnly: true
         description: "GeneratedPassword"
+        x-nullable:  false

--- a/rest-api/src/main/resources/definitions/guid_createdOn_version_holder.yml
+++ b/rest-api/src/main/resources/definitions/guid_createdOn_version_holder.yml
@@ -6,18 +6,22 @@ properties:
         type: string
         readOnly: true
         description: The guid of the survey (added when the survey is created).
+        x-nullable: false
     createdOn:
         type: string
         format: date-time
         readOnly: true
         description: The createdOn value of the survey (added when survey is created).
+        x-nullable: false
     version:
         type: integer
         format: int64
         readOnly: true
         description: |
             The optimistic locking version of the survey. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "GuidCreatedOnVersionHolder"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/guid_holder.yml
+++ b/rest-api/src/main/resources/definitions/guid_holder.yml
@@ -6,7 +6,9 @@ properties:
         type: string
         readOnly: true
         description: The guid of the newly created entity.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "GuidHolder"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/guid_version_holder.yml
+++ b/rest-api/src/main/resources/definitions/guid_version_holder.yml
@@ -6,13 +6,16 @@ properties:
         type: string
         readOnly: true
         description: The guid of the entity (added when the entity is created).
+        x-nullable: false
     version:
         type: integer
         format: int64
         readOnly: true
         description: |
             The optimistic locking version of the survey. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "GuidVersionHolder"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/health_data_record.yml
@@ -7,74 +7,93 @@ required:
 properties:
     appVersion:
         type: string
+        readOnly: true
         description: |
             App version, as reported by the app. Generally in the form "version 1.0.0, build 2". Must be 48 chars or less.
     createdOn:
         type: string
+        readOnly: true
         format: date-time
         description: ISO timestamp of when the data record was created, as reported by the submitting app
     createdOnTimeZone:
         type: string
+        readOnly: true
         description: The original timezone of the createdOn timestamp, expressed as a 4-digit string with sign. For example, -0800, +0900
     data:
         type: object
+        readOnly: true
         description: JSON map with key value pairs representing the record's data.
     id:
         type: string
+        readOnly: true
         description: A unique GUID for this record.
     metadata:
         type: object
+        readOnly: true
         description: |
             Arbitrary JSON blob of record metadata, as submitted by the app. For ResearchKit-based apps, this is info.json verbatim.
     phoneInfo:
         type: string
+        readOnly: true
         description: Phone info, for example "iPhone9,3" or "iPhone 5c (GSM)". Must be 48 chars or less.
     rawDataAttachmentId:
         type: string
+        readOnly: true
         description: |
             Attachment ID (S3 key) that contains the raw data. This is the unencrypted zip file for uploads, or JSON blob for directly submitted records
     schemaId:
         type: string
+        readOnly: true
         description: |
             [UploadSchema](#UploadSchema) ID for the record.
     schemaRevision:
         type: integer
+        readOnly: true
         format: int64
         description: |
             [UploadSchema](#UploadSchema) revision for the record.
     studyId:
         type: string
         description: Study that this record lives in.
+        readOnly: true
     uploadDate:
         type: string
         format: date
+        readOnly: true
         description: |
             Calendar date in YYYY-MM-DD format representing when the server received the upload, using the server's local time zone (US Pacific timezone).
     uploadId:
         type: string
+        readOnly: true
         description: The upload GUID of the upload this record is processed from.
     uploadedOn:
         type: string
+        readOnly: true
         format: date-time
         description: The date and time of the upload.
     userMetadata:
         type: object
+        readOnly: true
         description: |
             JSON map with key value pairs representing metadata for this health data record, as submitted by the app. This corresponds with the uploadMetadataFieldDefinitions configured in the study.
     userSharingScope:
         type: string
+        readOnly: true
         description: The user's sharing scope at the time of this upload's submission.
         $ref: ./enums/sharing_scope.yml
     userExternalId:
         type: string
+        readOnly: true
         description: The user's external ID at the time of this upload's submission.
     userDataGroups:
         type: array
+        readOnly: true
         description: The user's data groups at the time of this upload's submission.
         items:
             type: string
     userSubstudyMemberships:
         type: object
+        readOnly: true
         description: |
             A map where the keys are the substudy IDs assigned to the user at the time that user generated this 
             health data, and the values are the external IDs that were assigned to the user for each substudy (if no external ID was assigned, the value will be an empty string).
@@ -82,14 +101,17 @@ properties:
             type: string
     validationErrors:
         type: string
+        readOnly: true
         description: Error messages related to upload validation. Only generated if UploadValidationStrictness is set to REPORT.
     version:
         type: integer
+        readOnly: true
         format: int64
         description: |
             A version number issued for optimistic locking of record updates. Should not be set when creating a new health data record. When updating a record retrieved from the API, the object will have the version attribute and this must match the last value issued by the service or an update will fail.
     synapseExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/health_data_record.yml
@@ -15,10 +15,12 @@ properties:
         readOnly: true
         format: date-time
         description: ISO timestamp of when the data record was created, as reported by the submitting app
+        x-nullable: false
     createdOnTimeZone:
         type: string
         readOnly: true
         description: The original timezone of the createdOn timestamp, expressed as a 4-digit string with sign. For example, -0800, +0900
+        x-nullable: false
     data:
         type: object
         readOnly: true
@@ -27,6 +29,7 @@ properties:
         type: string
         readOnly: true
         description: A unique GUID for this record.
+        x-nullable: false
     metadata:
         type: object
         readOnly: true
@@ -41,6 +44,7 @@ properties:
         readOnly: true
         description: |
             Attachment ID (S3 key) that contains the raw data. This is the unencrypted zip file for uploads, or JSON blob for directly submitted records
+        x-nullable: false
     schemaId:
         type: string
         readOnly: true
@@ -56,31 +60,37 @@ properties:
         type: string
         description: Study that this record lives in.
         readOnly: true
+        x-nullable: false
     uploadDate:
         type: string
         format: date
         readOnly: true
         description: |
             Calendar date in YYYY-MM-DD format representing when the server received the upload, using the server's local time zone (US Pacific timezone).
+        x-nullable: false
     uploadId:
         type: string
         readOnly: true
         description: The upload GUID of the upload this record is processed from.
+        x-nullable: false
     uploadedOn:
         type: string
         readOnly: true
         format: date-time
         description: The date and time of the upload.
+        x-nullable: false
     userMetadata:
         type: object
         readOnly: true
         description: |
             JSON map with key value pairs representing metadata for this health data record, as submitted by the app. This corresponds with the uploadMetadataFieldDefinitions configured in the study.
+        x-nullable: false
     userSharingScope:
         type: string
         readOnly: true
         description: The user's sharing scope at the time of this upload's submission.
         $ref: ./enums/sharing_scope.yml
+        x-nullable: false
     userExternalId:
         type: string
         readOnly: true
@@ -91,6 +101,7 @@ properties:
         description: The user's data groups at the time of this upload's submission.
         items:
             type: string
+        x-nullable: false
     userSubstudyMemberships:
         type: object
         readOnly: true
@@ -99,20 +110,25 @@ properties:
             health data, and the values are the external IDs that were assigned to the user for each substudy (if no external ID was assigned, the value will be an empty string).
         additionalProperties:
             type: string
+        x-nullable: false
     validationErrors:
         type: string
         readOnly: true
         description: Error messages related to upload validation. Only generated if UploadValidationStrictness is set to REPORT.
+        x-nullable: false
     version:
         type: integer
         readOnly: true
         format: int64
         description: |
             A version number issued for optimistic locking of record updates. Should not be set when creating a new health data record. When updating a record retrieved from the API, the object will have the version attribute and this must match the last value issued by the service or an update will fail.
+        x-nullable: false
     synapseExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
         readOnly: true
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "HealthDataRecord"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/health_data_record.yml
@@ -10,6 +10,7 @@ properties:
         readOnly: true
         description: |
             App version, as reported by the app. Generally in the form "version 1.0.0, build 2". Must be 48 chars or less.
+        x-nullable: false
     createdOn:
         type: string
         readOnly: true
@@ -25,6 +26,7 @@ properties:
         type: object
         readOnly: true
         description: JSON map with key value pairs representing the record's data.
+        x-nullable: false
     id:
         type: string
         readOnly: true
@@ -35,10 +37,12 @@ properties:
         readOnly: true
         description: |
             Arbitrary JSON blob of record metadata, as submitted by the app. For ResearchKit-based apps, this is info.json verbatim.
+        x-nullable: false
     phoneInfo:
         type: string
         readOnly: true
         description: Phone info, for example "iPhone9,3" or "iPhone 5c (GSM)". Must be 48 chars or less.
+        x-nullable: false
     rawDataAttachmentId:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/health_data_submission.yml
+++ b/rest-api/src/main/resources/definitions/health_data_submission.yml
@@ -1,5 +1,9 @@
 description: Used to submit health data to the synchronous health data API.
 type: object
+required:
+    - appVersion
+    - data
+    - phoneInfo
 properties:
     appVersion:
         type: string

--- a/rest-api/src/main/resources/definitions/health_data_submission.yml
+++ b/rest-api/src/main/resources/definitions/health_data_submission.yml
@@ -40,3 +40,4 @@ properties:
         type: string
         readOnly: true
         description: "HealthDataSubmission"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/identifier.yml
+++ b/rest-api/src/main/resources/definitions/identifier.yml
@@ -12,7 +12,9 @@ properties:
     study:
         type: string  
         description: String identifier if the participant's study.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Identifier"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/identifier_holder.yml
+++ b/rest-api/src/main/resources/definitions/identifier_holder.yml
@@ -6,7 +6,9 @@ properties:
         type: string
         readOnly: true
         description: The identifier of the entity (added when the entity is created).
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "IdentifierHolder"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/identifier_update.yml
+++ b/rest-api/src/main/resources/definitions/identifier_update.yml
@@ -22,3 +22,4 @@ properties:
         type: string
         readOnly: true
         description: "IdentifierUpdate"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/image.yml
+++ b/rest-api/src/main/resources/definitions/image.yml
@@ -6,6 +6,7 @@ properties:
         type: string
         description: |
             An URL to an image. It is strongly recommended that the image be an SVG (vector graphics, re-scalable to the target device's screen size and resolution), **or** at least 600 by 400 pixels in size, if not larger (some phones have screens of up to 800 or more pixels across the screen).
+        x-nullable: false
     width:
         type: integer
         description: The width of the image in pixels. If image is present, this field is required.
@@ -16,3 +17,4 @@ properties:
         type: string
         readOnly: true
         description: "Image"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/intent_to_participate.yml
+++ b/rest-api/src/main/resources/definitions/intent_to_participate.yml
@@ -2,18 +2,16 @@ description: |
     For studies that wish to orchestrate an agreement to participate prior to signing up for a study, this API provides a way to store a consent under a phone number or email address. The user must submit a phone number *or* an email address (not both) as part of this submission, the same credential that will be used to sign up for the study. On first sign in, instead of receiving a 412 response, this user will be consented with this intent to participate record.
 type: object
 required:
-    - studyId
     - subpopGuid
+    - scope
     - consentSignature
 properties:
     studyId:
         type: string
         description: The identifier for the study in which the user consents to participate.
-        x-nullable: false
     subpopGuid:
         type: string
         description: The specific subpopulation sent in the study to which the user consents to participate.
-        x-nullable: false
     osName:
         type: string
         description: |
@@ -24,7 +22,6 @@ properties:
         type: string
     consentSignature:
         $ref: ./consent_signature.yml
-        x-nullable: false
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/intent_to_participate.yml
+++ b/rest-api/src/main/resources/definitions/intent_to_participate.yml
@@ -3,16 +3,17 @@ description: |
 type: object
 required:
     - studyId
-    - phone
     - subpopGuid
     - consentSignature
 properties:
     studyId:
         type: string
         description: The identifier for the study in which the user consents to participate.
+        x-nullable: false
     subpopGuid:
         type: string
         description: The specific subpopulation sent in the study to which the user consents to participate.
+        x-nullable: false
     osName:
         type: string
         description: |
@@ -23,7 +24,9 @@ properties:
         type: string
     consentSignature:
         $ref: ./consent_signature.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "IntentToParticipate"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/invalid_entity.yml
+++ b/rest-api/src/main/resources/definitions/invalid_entity.yml
@@ -5,9 +5,11 @@ readOnly: true
 properties:
     message:
         type: string
+        readOnly: true
         description: A message that will include all validation error messages for this object.
     errors:
         type: object
+        readOnly: true
         description: |
             Errors broken down by the part of the JSON payload that generated them. The keys are "paths" representing fragments of the JSON (expressed in JavaScript object/array notation), and the values are string arrays of one or more errors for that element of the JSON. An example makes this clearer:
 

--- a/rest-api/src/main/resources/definitions/invalid_entity.yml
+++ b/rest-api/src/main/resources/definitions/invalid_entity.yml
@@ -1,7 +1,6 @@
 description: |
     Payload returned with a 400 error when an entity submitted to the server is invalid.
 type: object
-readOnly: true
 properties:
     message:
         type: string

--- a/rest-api/src/main/resources/definitions/invalid_entity.yml
+++ b/rest-api/src/main/resources/definitions/invalid_entity.yml
@@ -7,6 +7,7 @@ properties:
         type: string
         readOnly: true
         description: A message that will include all validation error messages for this object.
+        x-nullable: false
     errors:
         type: object
         readOnly: true
@@ -33,3 +34,4 @@ properties:
             type: array
             items:
                 type: string
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/message.yml
+++ b/rest-api/src/main/resources/definitions/message.yml
@@ -3,3 +3,9 @@ properties:
     message:
         type: string
         readOnly: true
+        x-nullable: false
+    type:
+        type: string
+        readOnly: true
+        description: "StatusMessage"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/notification_message.yml
+++ b/rest-api/src/main/resources/definitions/notification_message.yml
@@ -7,11 +7,14 @@ properties:
         type: string
         description: |
             Very short rendition of the notification. For example, this value will be displayed on an Apple iWatch, where the message is shown for a short time only.
+        x-nullable: false
     message:
         type: string
         description: |
             Full notification message.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "NotificationMessage"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/notification_registration.yml
+++ b/rest-api/src/main/resources/definitions/notification_registration.yml
@@ -2,36 +2,45 @@ type: object
 required:
     - deviceId
     - osName
+    - protocol
 properties:
     guid:
         type: string
+        x-nullable: false
     protocol:
         $ref: ./enums/notification_protocol.yml
+        x-nullable: false
     endpoint:
         description: |
             The endpoint that should be registered for the notification. For "sms" protocol, this is the participant's verified phone number in string form. For "application" protocol, this is the endpointARN generated when the user's device is registered for a specific platform (using a platformARN).
         type: string
+        x-nullable: false
     deviceId:
         description: |
             This should be either the device token retrieved from the iOS operation system, or the registrationId on Android.
         type: string
+        x-nullable: false
     osName:
         description: |
             Information used to track which type of deviceId is being submitted. This string should be either "Android" or "iPhone OS" ("iOS" also works), and should match the operating system from which you retrieved a push notification identifier (deviceId).
         type: string
+        x-nullable: false
     createdOn:
         description: |
             Date the client registered for push notifications with Bridge.
         type: string
         format: date-time
         readOnly: true
+        x-nullable: false
     modifiedOn:
         description: |
             The last time the registration was updated based on a new device identifier being issued by the client operating system (iOS or Android). If an updated registration is submitted but the deviceId has not changed, the record is not modified.
         type: string
         format: date-time
         readOnly: true
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "NotificationRegistration"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/notification_topic.yml
+++ b/rest-api/src/main/resources/definitions/notification_topic.yml
@@ -1,18 +1,22 @@
 type: object
 required:
     - name
+    - shortName
 properties:
     guid:
         description: A unique GUID for this topic
         type: string
+        x-nullable: false
     name:
         description: |
             The name of this topic (visible to developers and researchers in design tools).
         type: string
+        x-nullable: false
     shortName:
         description: |
             Short name for the topic, used as the display name for the topic in SNS. This also appears in SMS notifications. Must be 10 characters or less.
         type: string
+        x-nullable: false
     description:
         description: |
             Description of the purpose of this topic (visible to developers and researchers in design tools).
@@ -23,19 +27,24 @@ properties:
         type: string
         format: date-time
         readOnly: true
+        x-nullable: false
     modifiedOn:
         description: |
             The date and time this topic was last modified.
         type: string
         format: date-time
         readOnly: true
+        x-nullable: false
     deleted:
         type: boolean
+        x-nullable: false
     criteria:
         $ref: ./criteria.yml
         description: |
             If a topic has criteria, users can be automatically subscribed and unsubscribed when their criteria context changes.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "NotificationTopic"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/oauth_access_token.yml
+++ b/rest-api/src/main/resources/definitions/oauth_access_token.yml
@@ -1,8 +1,4 @@
 type: object
-required:
-    - vendorId
-    - accessToken
-    - expiresOn
 properties:
     vendorId:
         type: string

--- a/rest-api/src/main/resources/definitions/oauth_access_token.yml
+++ b/rest-api/src/main/resources/definitions/oauth_access_token.yml
@@ -8,20 +8,25 @@ properties:
         type: string
         readOnly: true
         description: The Bridge-assigned vendor ID.
+        x-nullable: false
     accessToken:
         type: string
         readOnly: true
         description: The access token.
+        x-nullable: false
     expiresOn:
         type: string
         format: date-time
         readOnly: true
         description: The ISO 8601 timestamp of when this access token will expire.
+        x-nullable: false
     providerUserId:
         type: string
         readOnly: true
         description: The provider's ID for this user.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "OAuthAccessToken"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/oauth_authorization_token.yml
+++ b/rest-api/src/main/resources/definitions/oauth_authorization_token.yml
@@ -4,7 +4,9 @@ properties:
         type: string
         description: |
             The OAuth 2.0 authorization token returned from the provider, which must be submitted to the Bridge server in order to retrieve an access token. This token is optional, but if provided, Bridge server will always renew the access token with the OAuth provider.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "OAuthAuthorizationToken"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/oauth_provider.yml
+++ b/rest-api/src/main/resources/definitions/oauth_provider.yml
@@ -8,17 +8,22 @@ properties:
     clientId:
         type: string
         description: The client ID of the app.
+        x-nullable: false
     secret:
         type: string
         description: The secret token that the server must provide.
+        x-nullable: false
     endpoint:
         type: string
         description: The URL to send an authorization token to to retrieve access and refresh tokens.
+        x-nullable: false
     callbackUrl:
         type: string
         description: |
             The callback URL that the client provides to retrieve the authorization token. This must match that callback URL exactly.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "OAuthProvider"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/paged_resources/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/account_summary.yml
@@ -8,5 +8,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../account_summary.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/activity.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../scheduled_activity.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/activity_event.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/activity_event.yml
@@ -1,13 +1,12 @@
 type: object
 readOnly: true
-required:
-    - items
-properties:
-    items:
-        type: array
+allOf:
+    - $ref: ./resource_list.yml
+    - required:
+        - items
+    - properties:
         items:
-            $ref: ../activity_event.yml
-    type:
-        type: string
-        readOnly: true
-        description: "ResourceList"
+            type: array
+            readOnly: true
+            items:
+                $ref: ../activity_event.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/app_config.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/app_config.yml
@@ -1,13 +1,12 @@
 type: object
 readOnly: true
-required:
-    - items
-properties:
-    items:
-        type: array
+allOf:
+    - $ref: ./resource_list.yml
+    - required:
+        - items
+    - properties:
         items:
-            $ref: ../app_config.yml
-    type:
-        type: string
-        readOnly: true
-        description: "ResourceList"
+            type: array
+            readOnly: true
+            items:
+                $ref: ../app_config.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/app_config_element.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/app_config_element.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../app_config_element.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/compound_activity_definition.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/compound_activity_definition.yml
@@ -7,6 +7,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../compound_activity_definition.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/external_identifier.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/external_identifier.yml
@@ -7,5 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../external_identifier.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_paged_resource_list.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/forward_cursor_paged_resource_list.yml
@@ -6,13 +6,16 @@ description: |
 properties:
     requestParams:
         $ref: ../request_params.yml
+        readOnly: true
     nextPageOffsetKey:
         type: string
+        readOnly: true
         description: |
             The offsetKey to be provided in the next request to get the next page of 
             resources.
     hasNext:
         type: boolean
+        readOnly: true
         description: true if there is a further page of resources, false otherwise.
     type:
         type: string

--- a/rest-api/src/main/resources/definitions/paged_resources/health_data_record.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/health_data_record.yml
@@ -9,6 +9,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../health_data_record.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/notification_registration.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/notification_registration.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../notification_registration.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/notification_topic.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/notification_topic.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../notification_topic.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/paged_resource_list.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/paged_resource_list.yml
@@ -2,6 +2,7 @@ type: object
 properties:
     requestParams:
         $ref: ../request_params.yml
+        readOnly: true
     total:
         type: integer
         readOnly: true

--- a/rest-api/src/main/resources/definitions/paged_resources/paged_string.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/paged_string.yml
@@ -7,5 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 type: string

--- a/rest-api/src/main/resources/definitions/paged_resources/report_data.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/report_data.yml
@@ -7,6 +7,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../report_data.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/report_index.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/report_index.yml
@@ -7,6 +7,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../report_index.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/resource_list.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/resource_list.yml
@@ -7,6 +7,7 @@ description: |
 properties:
     requestParams:
         $ref: ../request_params.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/paged_resources/schedule.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/schedule.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../schedule.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/schedule_plan.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/schedule_plan.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../schedule_plan.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../scheduled_activity.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity_v4.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/scheduled_activity_v4.yml
@@ -9,6 +9,7 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../scheduled_activity.yml
         type:

--- a/rest-api/src/main/resources/definitions/paged_resources/shared_module_metadata.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/shared_module_metadata.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../shared_module_metadata.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/string.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/string.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 type: string
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/study.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/study.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../study.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/study_consent.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/study_consent.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../study_consent.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/subpopulation.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/subpopulation.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../subpopulation.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/subscription_status.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/subscription_status.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../subscription_status.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/substudy.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/substudy.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../substudy.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/survey.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/survey.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../survey.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/paged_resources/upload.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/upload.yml
@@ -7,5 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../upload.yml

--- a/rest-api/src/main/resources/definitions/paged_resources/upload_schema.yml
+++ b/rest-api/src/main/resources/definitions/paged_resources/upload_schema.yml
@@ -7,9 +7,6 @@ allOf:
     - properties:
         items:
             type: array
+            readOnly: true
             items:
                 $ref: ../upload_schema.yml
-        type:
-            type: string
-            readOnly: true
-            description: "ResourceList"

--- a/rest-api/src/main/resources/definitions/password_policy.yml
+++ b/rest-api/src/main/resources/definitions/password_policy.yml
@@ -1,8 +1,6 @@
 description: |
     The rules to enforce on the creation of passwords for Bridge accounts.
 type: object
-required:
-    - minLength
 properties:
     minLength:
         type: integer
@@ -10,26 +8,32 @@ properties:
         maximum: 100
         default: 8
         description: The minimum number of characters that's required in the password.
+        x-nullable: false
     numericRequired:
         type: boolean
         default: true
         description: Is at least one number required in the password? (0-9).
+        x-nullable: false
     symbolRequired:
         type: boolean
         default: true
         description: |
             Is at least one ASCII symbol (non-letter, non-number) required in the 
             password? (! " # $ % &amp; ' ( ) * + , - . / : ; &lt; = &gt; ? @ [ \ ] ^ _ ` { ¦ } ~).
+        x-nullable: false
     lowerCaseRequired:
         type: boolean
         default: true
         description: Is at least one lower-case letter required? (a-z).
+        x-nullable: false
     upperCaseRequired:
         type: boolean
         default: true
         description: Is at least one upper-case letter required? (A-Z).
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "PasswordPolicy"                
+        x-nullable: false
     

--- a/rest-api/src/main/resources/definitions/password_reset.yml
+++ b/rest-api/src/main/resources/definitions/password_reset.yml
@@ -16,3 +16,4 @@ properties:
         type: string
         readOnly: true
         description: "PasswordReset"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/phone.yml
+++ b/rest-api/src/main/resources/definitions/phone.yml
@@ -7,15 +7,19 @@ properties:
     number:
         type: string
         description: The phone number (can be formatted in any way that's useful for end users).
+        x-nullable: false
     regionCode:
         type: string
         description: CLDR two-letter region code describing the region in which the phone number was issued.
+        x-nullable: false
     nationalFormat:
         type: string
         readOnly: true
         description: |
             The phone number formatted in the commonly accepted national format of the region code. This value is read-only.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Phone"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/phone_signin.yml
+++ b/rest-api/src/main/resources/definitions/phone_signin.yml
@@ -19,3 +19,4 @@ properties:
         type: string
         readOnly: true
         description: "PhoneSignIn"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/phone_signin_request.yml
+++ b/rest-api/src/main/resources/definitions/phone_signin_request.yml
@@ -14,3 +14,5 @@ properties:
         type: string
         readOnly: true
         description: "PhoneSignInRequest"
+        x-nullable: false
+

--- a/rest-api/src/main/resources/definitions/record_export_status_request.yml
+++ b/rest-api/src/main/resources/definitions/record_export_status_request.yml
@@ -10,9 +10,12 @@ properties:
         description: One or more [HealthDataRecord](#HealthDataRecord) IDS.
         items:
             type: string
+        x-nullable: false
     synapseExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "RecordExportStatusRequest"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/report_data.yml
+++ b/rest-api/src/main/resources/definitions/report_data.yml
@@ -6,7 +6,6 @@ description:
     Data can be for a study as a whole, or a report on a single participant, depending on the endpoint that is used to persist the data in Bridge. 
 type: object
 required:
-    - date
     - data
 properties:
     date:
@@ -23,12 +22,15 @@ properties:
     data:
         type: object
         description: An arbitrary JSON object containing whatever data should be saved for a report.
+        x-nullable: false
     substudyIds:
         type: array
         description: The substudies this report record is associated to (these are set with the first record that is submitted and that creates a report index, and cannot be changed afterward unless the user is a study-wide user not associated to any specific substudy.
         items:
             type: string
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ReportData"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/report_data_for_worker.yml
+++ b/rest-api/src/main/resources/definitions/report_data_for_worker.yml
@@ -2,13 +2,13 @@ description:
     The JSON data to submit a report record for a point in time (curently a day expressed in the format YYYY-MM-DD). This object includes a healthCode because worker processes, as they produce records for a participant report, may be working from anonymized data. 
 type: object
 required:
-    - date
     - data
 properties:
     healthCode:
         type: string
         description: |
             The health code of the person for whom this data is being created.
+        x-nullable: false
     date:
         type: string
         format: date
@@ -20,12 +20,15 @@ properties:
     data:
         type: object
         description: An arbitrary JSON object containing whatever data should be saved for a report.
+        x-nullable: false
     substudyIds:
         type: array
         description: The substudies this report record is associated to (these are set with the first record that is submitted and that creates a report index, and cannot be changed afterward unless the user is a study-wide user not associated to any specific substudy.
         items:
             type: string
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ReportData"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/report_index.yml
+++ b/rest-api/src/main/resources/definitions/report_index.yml
@@ -8,16 +8,20 @@ properties:
     identifier:
         type: string
         description: The report identifier.
+        x-nullable: false
     substudyIds:
         type: array
         description: The substudies these report records are associated to.
         items:
             type: string
+        x-nullable: false
     public:
         type: boolean
         description: |
             Study reports can be marked as "public", which will make them accessible through the API to any requester (authentication is not required).
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ReportIndex"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/request_info.yml
+++ b/rest-api/src/main/resources/definitions/request_info.yml
@@ -17,48 +17,57 @@ required:
 properties:
     userId:
         type: string
+        readOnly: true
         description: The user's account ID.
     clientInfo:
         $ref: ./client_info.yml
+        readOnly: true
         description: |
             The `User-Agent` string from the last request as parsed for the purpose of applying filtering criteria.
     userAgent:
         type: string
+        readOnly: true
         description: |
             The `User-Agent` header exactly as it was sent to the server, whether it is parseable by the Bridge server or not. 
     languages:
         type: array
+        readOnly: true
         description: |
             The language or languages sent in the user's `Accept-Language` header and persisted as part of the participant's account configuration, as they were set at the time of the last request.
         items:
             type: string
     userDataGroups:
         type: array
+        readOnly: true
         description: The data groups assigned to this participant at the time of the last request.
         items:
             type: string
     activitiesAccessedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The last recorded time the participant's application requested scheduled activities from the server.
     signedInOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The last recorded time the participant signed in to the server.
     uploadedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The last recorded time the participant started an upload to the server.
     timeZone:
         type: string
+        readOnly: true
         description: The user's time zone at the time of the last request.
     studyIdentifier:
         $ref: ./study_identifier.yml
     type:
         type: string
         readOnly: true
-        description: "ClientInfo"
+        description: "RequestInfo"
     

--- a/rest-api/src/main/resources/definitions/request_info.yml
+++ b/rest-api/src/main/resources/definitions/request_info.yml
@@ -8,7 +8,6 @@ description: |
 
     This information is cached but not persisted; it is not guaranteed to be present for all active users.
 type: object
-readOnly: true
 properties:
     userId:
         type: string
@@ -60,9 +59,6 @@ properties:
         type: string
         readOnly: true
         description: The user's time zone at the time of the last request.
-    studyIdentifier:
-        $ref: ./study_identifier.yml
-        x-nullable: false
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/request_info.yml
+++ b/rest-api/src/main/resources/definitions/request_info.yml
@@ -9,16 +9,12 @@ description: |
     This information is cached but not persisted; it is not guaranteed to be present for all active users.
 type: object
 readOnly: true
-required:
-    - userId
-    - studyIdentifier
-    - languages
-    - userDataGroups
 properties:
     userId:
         type: string
         readOnly: true
         description: The user's account ID.
+        x-nullable: false
     clientInfo:
         $ref: ./client_info.yml
         readOnly: true
@@ -66,8 +62,10 @@ properties:
         description: The user's time zone at the time of the last request.
     studyIdentifier:
         $ref: ./study_identifier.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "RequestInfo"
+        x-nullable: false
     

--- a/rest-api/src/main/resources/definitions/request_params.yml
+++ b/rest-api/src/main/resources/definitions/request_params.yml
@@ -79,3 +79,4 @@ properties:
         type: string
         readOnly: true
         description: "RequestParams"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/schedule.yml
+++ b/rest-api/src/main/resources/definitions/schedule.yml
@@ -11,8 +11,10 @@ properties:
     label:
         type: string
         description: A label to describe this schedule.
+        x-nullable: false
     scheduleType:
         $ref: ./enums/schedule_type.yml
+        x-nullable: false
     eventId:
         type: string
         description: |
@@ -54,17 +56,21 @@ properties:
             type: string
             description: |
                 24hr time value(s) without a time zone (e.g. "14:30"). **Each time value will create a separate task, one for each activity in the schedule.**
+        x-nullable: false
     persistent:
         type: boolean
         description: True if schedule type is persistent. (This is here for legacy reasons.)
+        x-nullable: false
     activities:
         type: array
         description: |
             One or more activities that should be done by a participant on this schedule. Each activity will generate a separate task. See Activity.
         items:
             $ref: ./activity.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Schedule"
+        x-nullable: false
     

--- a/rest-api/src/main/resources/definitions/schedule_criteria.yml
+++ b/rest-api/src/main/resources/definitions/schedule_criteria.yml
@@ -7,9 +7,12 @@ required:
 properties:
     criteria:
         $ref: ./criteria.yml
+        x-nullable: false
     schedule:
         $ref: ./schedule.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ScheduleCriteria"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/schedule_plan.yml
+++ b/rest-api/src/main/resources/definitions/schedule_plan.yml
@@ -2,9 +2,7 @@ description: |
     A schedule plan relates schedules to some specific strategies for using these schedules to create activities for participants.
 type: object
 required:
-    - guid
     - label
-    - version
     - strategy
 properties:
     guid:

--- a/rest-api/src/main/resources/definitions/schedule_plan.yml
+++ b/rest-api/src/main/resources/definitions/schedule_plan.yml
@@ -9,24 +9,31 @@ required:
 properties:
     guid:
         type: string
+        x-nullable: false
     label:
         type: string
         description: The name of this schedule plan (not shown to users).
+        x-nullable: false
     modifiedOn:
         type: string
         format: date-time
         readOnly: true
+        x-nullable: false
     deleted:
         type: boolean
+        x-nullable: false
     strategy:
         $ref: ./schedule_strategy.yml
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The optimistic locking version of the survey. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "SchedulePlan"
+        x-nullable: false
     

--- a/rest-api/src/main/resources/definitions/schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/schedule_strategy.yml
@@ -7,3 +7,4 @@ description: |
 properties:
     type:
         type: string
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/schedule_strategy.yml
@@ -1,7 +1,5 @@
 type: object
 discriminator: type
-required:
-    - type
 description: |
     This is an interface for several implementations. See [scheduling](/articles/scheduling.html) for further information on creating schedules.
 properties:

--- a/rest-api/src/main/resources/definitions/scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/scheduled_activity.yml
@@ -1,8 +1,6 @@
 description: |
     Description of an activity (such as a task or survey) the study would like the participant to perform. A scheduled activity will contain a reference to a task, a survey, a compound task (which can include any combination of tasks and surveys), and the activityType will reflect which property exists on the scheduled activity object (e.g. if a task is defined, the activityType will be "task"). 
 type: object
-required:
-    - guid
 properties:
     guid:
         type: string

--- a/rest-api/src/main/resources/definitions/scheduled_activity.yml
+++ b/rest-api/src/main/resources/definitions/scheduled_activity.yml
@@ -6,9 +6,11 @@ required:
 properties:
     guid:
         type: string
+        x-nullable: false
     schedulePlanGuid:
         type: string
         readOnly: true
+        x-nullable: false
     startedOn:
         type: string
         format: date-time
@@ -23,6 +25,7 @@ properties:
         readOnly: true
         description: |
             The time at which the activity should be made available to the participant. It's fine to show the activity before this, but the user should not be able to start it until this time has passed. Time will be expressed in the time zone sent to the server to request the scheduled activities.
+        x-nullable: false
     expiresOn:
         type: string
         format: date-time
@@ -32,11 +35,13 @@ properties:
     activity:
         $ref: ./activity.yml 
         readOnly: true
+        x-nullable: false
     persistent:
         type: boolean
         description: |
             Is this activity persistent? If so, it will never be removed from the list of activities; the client may wish to provide different UI for such a task.
         readOnly: true
+        x-nullable: false
     clientData:
         type: object
         description: |
@@ -47,7 +52,9 @@ properties:
             ```
     status:
         $ref: ./enums/schedule_status.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "ScheduledActivity"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/schema_reference.yml
+++ b/rest-api/src/main/resources/definitions/schema_reference.yml
@@ -7,6 +7,7 @@ properties:
     id:
         type: string
         description: Schema ID
+        x-nullable: false
     revision:
         type: integer
         format: int64
@@ -16,3 +17,4 @@ properties:
         type: string
         readOnly: true
         description: "SchemaReference"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/shared_module_import_status.yml
+++ b/rest-api/src/main/resources/definitions/shared_module_import_status.yml
@@ -5,6 +5,7 @@ properties:
     moduleType:
         $ref: ./enums/shared_module_type.yml
         readOnly: true
+        x-nullable: false
     schemaId:
         type: string
         description: Schema ID, if this module is a schema.
@@ -21,3 +22,4 @@ properties:
         type: string
         readOnly: true
         description: "SharedModuleImportStatus"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/shared_module_metadata.yml
+++ b/rest-api/src/main/resources/definitions/shared_module_metadata.yml
@@ -13,6 +13,7 @@ properties:
     licenseRestricted:
         type: boolean
         description: True if usage of this module is restricted by license or copyright.
+        x-nullable: false
     moduleType:
         $ref: ./enums/shared_module_type.yml
         readOnly: true

--- a/rest-api/src/main/resources/definitions/shared_module_metadata.yml
+++ b/rest-api/src/main/resources/definitions/shared_module_metadata.yml
@@ -9,15 +9,18 @@ properties:
     id:
         type: string
         description: Unique ID of the module.
+        x-nullable: false
     licenseRestricted:
         type: boolean
         description: True if usage of this module is restricted by license or copyright.
     moduleType:
         $ref: ./enums/shared_module_type.yml
         readOnly: true
+        x-nullable: false
     name:
         type: string
         description: User-friendly module name.
+        x-nullable: false
     notes:
         type: string
         description: User-friendly descriptive notes for the module.
@@ -28,6 +31,7 @@ properties:
         type: boolean
         description: |
             Flag that marks the module as published. A published module versions cannot be modified. However, another version of the same module can be created for continued editing.
+        x-nullable: false
     schemaId:
         type: string
         description: Schema ID, if this module is a schema.
@@ -45,13 +49,17 @@ properties:
         description: An unordered list of tags, used for querying and filtering.
         items:
             type: string
+        x-nullable: false
     deleted:
         type: boolean
         description: Has this shared module metadata been logically deleted (an admin can restore it)?
+        x-nullable: false
     version:
         type: integer
         description: Module version.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "SharedModuleMetadata"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/sharing_scope_form.yml
+++ b/rest-api/src/main/resources/definitions/sharing_scope_form.yml
@@ -8,3 +8,4 @@ properties:
         type: string
         readOnly: true
         description: "SharingScope"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/sign_in.yml
+++ b/rest-api/src/main/resources/definitions/sign_in.yml
@@ -27,4 +27,4 @@ properties:
         type: string
         readOnly: true
         description: "SignIn"
-        
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/sign_up.yml
+++ b/rest-api/src/main/resources/definitions/sign_up.yml
@@ -5,8 +5,6 @@ allOf:
     - type: object
     - required:
         - study
-        - email
-        - password
     - properties:
         study:
             type: string
@@ -34,3 +32,4 @@ allOf:
             type: string
             readOnly: true
             description: "SignUp"
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/simple_schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/simple_schedule_strategy.yml
@@ -5,8 +5,12 @@ allOf:
     - type: object
     - required:
         - schedule
-        - type
     - properties:
         schedule:
             $ref: ./schedule.yml
+            x-nullable: false
+        type:
+            type: string
+            readOnly: true
+            description: "SimpleScheduleStrategy"
             x-nullable: false

--- a/rest-api/src/main/resources/definitions/simple_schedule_strategy.yml
+++ b/rest-api/src/main/resources/definitions/simple_schedule_strategy.yml
@@ -9,3 +9,4 @@ allOf:
     - properties:
         schedule:
             $ref: ./schedule.yml
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/sms_message.yml
+++ b/rest-api/src/main/resources/definitions/sms_message.yml
@@ -1,36 +1,37 @@
 type: object
 description: Represents an SMS message that we sent to a phone number.
-required:
-    - phoneNumber
-    - sentOn
-    - messageBody
-    - messageId
-    - smsType
-    - studyId
 properties:
     phoneNumber:
         type: string
         description: The phone number receiving this message, formatted in E.164 international format.
+        x-nullable: false
     sentOn:
         type: string
         format: date-time
         description: Timestamp in ISO8601 format when we sent the message.
+        x-nullable: false
     healthCode:
         type: string
         description: |
             Health code of the participant that received the message, if the participant had an account at the time the message was sent.
+        x-nullable: false
     messageBody:
         type: string
         description: The message content we sent.
+        x-nullable: false
     messageId:
         type: string
         description: Message ID, as determined by the SMS provider.
+        x-nullable: false
     smsType:
         $ref: ./enums/sms_type.yml
+        x-nullable: false
     studyId:
         type: string
         description: The study whose behalf we sent the message.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "SmsMessage"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/sms_template.yml
+++ b/rest-api/src/main/resources/definitions/sms_template.yml
@@ -65,7 +65,9 @@ properties:
         type: string
         description: |
           The message to send (only text and template variables allowed). 
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "SmsTemplate"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/study.yml
+++ b/rest-api/src/main/resources/definitions/study.yml
@@ -3,19 +3,11 @@ description: |
 type: object
 required:
     - name
+    - shortName
     - sponsorName
     - supportEmail
-    - technicalEmail
     - identifier
-    - consentNotificationEmail
     - version
-    - userProfileAttributes
-    - uploadMetadataFieldDefinitions
-    - taskIdentifiers
-    - activityEventKeys
-    - dataGroups
-    - appleAppLinks
-    - androidAppLinks
 properties:
     name:
         type: string
@@ -40,7 +32,6 @@ properties:
     consentNotificationEmailVerified:
         description: True if the consent notification email is verified. False if not.
         type: boolean
-        x-nullable: false
     installLinks:
         type: object
         description: |

--- a/rest-api/src/main/resources/definitions/study.yml
+++ b/rest-api/src/main/resources/definitions/study.yml
@@ -20,22 +20,27 @@ properties:
     name:
         type: string
         description: A label for the study. This will be shown to users in emails and other contexts.
+        x-nullable: false
     shortName:
         type: string
         description: A very short label (10 characters or less) for SMS messages and any other highly constrainted contexts.
+        x-nullable: false
     automaticCustomEvents:
         type: object
         description: |
             Custom events that should be generated for participant upon enrollment. The key in this map is the eventKey, and the value is the offset after the enrollment event (eg, "P1D" for one day after enrollment, "P-2W" for 2 weeks before enrollment). Note that this API will automatically pre-pend "custom:" in front of the event key when generating the eventId (eg, eventKey "studyBurstStart" becomes event ID "custom:studyBurstStart").
         additionalProperties:
             type: string
+        x-nullable: false
     autoVerificationEmailSuppressed:
         description: |
             True if the automatic email verification email on sign-up should be suppressed. False if the email should be sent on sign-up. This is generally used in conjunction with email sign-in, where sending a separate email verification email would be redundant.
         type: boolean
+        x-nullable: false
     consentNotificationEmailVerified:
         description: True if the consent notification email is verified. False if not.
         type: boolean
+        x-nullable: false
     installLinks:
         type: object
         description: |
@@ -44,16 +49,20 @@ properties:
             precedence over the Universal URL.
         additionalProperties:
             type: string
+        x-nullable: false
     participantIpLockingEnabled:
         description: True if sessions for unprivileged participant accounts should be locked to an IP address. (Privileged account sessions are _always_ locked to an IP address.)
         type: boolean
+        x-nullable: false
     sponsorName:
         type: string
         description: The name of the institution or organization that is conducting the study. 
+        x-nullable: false
     supportEmail:
         type: string
         description: |
             The email address that will be given to study participants and other end users to contact for support requests. This can be a comma-separated list of email addresses. Email will be sent via this email address.
+        x-nullable: false
     technicalEmail:
         type: string
         description: |
@@ -66,8 +75,10 @@ properties:
             All metadata field definitions are implicitly optional. The "required" field in metadata field definitions is ignored.
         items:
             $ref: ./upload_field_definition.yml
+        x-nullable: false
     uploadValidationStrictness:
         $ref: ./enums/upload_validation_strictness.yml
+        x-nullable: false
     consentNotificationEmail:
         type: string
         description: |
@@ -76,22 +87,26 @@ properties:
         type: string
         description: |
             A user selected identifier that is unique relative to all other Bridge studies (lower-case letters and dashes only). The identifier serves as a "domain" that scopes accounts to that study, and is usually created by combining an institution and study tag or acronym. For example, if you work at the University of Washington and your study is on Asthma in Children, your identifier might be `uw-child-asthma`. Participants will not see this identifier.
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             A version number used for optimistic locking of the object these keys represent; this value must be passed back to the server on updates. If the version doesn't match the version in the database, an error will be returned (409 Conflict) and the study will not be saved. 
+        x-nullable: false
     minAgeOfConsent:
         type: integer
         default: 18
         description: |
             The minimum required age for participants in the study. If the user reports they are younger than this age, they will not be allowed to consent to the research.
+        x-nullable: false
     studyIdExcludedInExport:
         description: |
             True if the Bridge Exporter should include the studyId prefix in the "originalTable" field in the appVersion (now "Health Data Summary") table in Synapse. This is false for legacy studies for backwards compatibility, but is true for all new studies being created.
 
             This can only be changed by a Bridge admin. Care should be taken before changing this setting, as it may partition the data in Synapse.
         type: boolean
+        x-nullable: false
     synapseDataAccessTeamId:
         type: integer
         format: int64
@@ -104,71 +119,87 @@ properties:
         type: boolean
         description: |
             **Note: Bridge engineers will normally set this value when setting up data export. You should probably leave this setting as is.** By default, all studies are exported using the default nightly schedule. Some studies may need custom schedules for hourly or on-demand exports. To prevent this study from being exported twice (once by the custom schedule, once by the default schedule), you should set this attribute to true.
+        x-nullable: false
     userProfileAttributes:
         type: array
         description: |
             Custom attributes that can be added to the StudyParticipant object (as members of the attributes property). For example, if you wished to collect a telephone number for participants and had permission to do so, you could add the "telephone" attribute. The map of a user's profile attributes can be personally identifying health information; it will be stored encrypted and in a separate data store from the participant's health data.
         items:
             type: string
+        x-nullable: false
     taskIdentifiers:
         type: array
         description: |
             An enumerated list of **unique** strings that can be used to identify tasks when creating schedules. These mostly serve to prevent typos when designing schedules, which would prevent client scheduling from working. There's no hard limit on the string content (e.g. "Tapping Test" is fine as a task identifier, as long as it uniquely identifies a task known to the application).
         items:
             type: string
+        x-nullable: false
     activityEventKeys:
         type: array
         description: |
             The enumerated activity event keys for timestamps that can be recorded for use when scheduling tasks. These are provided through the UI to prevent errors when creating schedules. These form a whitelist for custom activity events that may be recorded for a participant.
         items:
             type: string
+        x-nullable: false
     dataGroups:
         type: array
         description: |
             An enumerated list of **unique** strings that can be assigned to user accounts. This is a list of the "tags" that can be assigned to a given user. The specific data groups that *are* assigned to a user will be exported with a participant's health data to Synapse. This can be used to identify test users or specific cohorts in the study, but it should not include sensitive health information about participants. Strings must contain only letters, numbers, underscore or dash, and cannot (as a comma-separated list) exceed the character limit of 100 characters so they can be exported to Synapse.
         items:
             type: string
+        x-nullable: false
     passwordPolicy:
         description: |
             Settings that will govern what is accepted as a valid password when users sign up for the study. If not included, the password policy will default to requiring 8 characters, including lower and upper-case letters, at least one number and at least one symbol.
         $ref: ./password_policy.yml
+        x-nullable: false
     verifyEmailTemplate:
         description: |
             The template for emails delivered to users during sign up, asking them to verify their email address.
         $ref: ./email_template.yml
+        x-nullable: false
     resetPasswordTemplate:
         description: The template for emails delivered to users who ask to reset their passwords.
         $ref: ./email_template.yml
+        x-nullable: false
     emailSignInTemplate:
         description: The template for an email that will contain a token to generate a session on the server.
         $ref: ./email_template.yml
+        x-nullable: false
     accountExistsTemplate:
         description: |
             The template for an email that will be sent if a user tries to sign up for a study more than once. It provides a means for the user to reset their password, if needed.
         $ref: ./email_template.yml
+        x-nullable: false
     appInstallLinkTemplate:
         $ref: ./email_template.yml
         description: The template for an email that will be sent if the user submits an intent to participate, directing the user to an appstore link to download your app. Template variable ${appInstallUrl} is required.
+        x-nullable: false
     active:
         type: boolean
         readOnly: true
+        x-nullable: false
     strictUploadValidationEnabled:
         description: True if uploads in this study should fail on strict validation errors.
         type: boolean
+        x-nullable: false
     healthCodeExportEnabled:
         type: boolean
         description: |
             **Can only be set by an administrator.** Should user health codes be exported as part of the participant roster? This identifies users in the public data set; this can only be set to true for certain studies where users expect to be identified by researchers.
+        x-nullable: false
     emailVerificationEnabled:
         type: boolean
         description: |
             **Can only be set by an administrator.** Should users be asked to validate that they control the email addresses they use to sign up for the study? True by default.  (Using an email address to send a 
             sign in link will also verify it.)
+        x-nullable: false
     autoVerificationPhoneSuppressed:
         type: boolean
         description: |
             **Can only be set by an administrator.** Should the system send a confirmation SMS message on sign 
             up if phone verification is enabled?
+        x-nullable: false
     externalIdValidationEnabled:
         type: boolean
         default: false
@@ -178,88 +209,107 @@ properties:
             * When assigned, the ID will have to match one of the IDs entered into Bridge;
             * A given ID will be assigned to one and only one user;
             * Once assigned, it is not possible to change or remove the external ID from the user account.
+        x-nullable: false
     emailSignInEnabled:
         type: boolean
         default: false
         description: |
             **Can only be set by an administrator.** If enabled, the user will be able to trigger an email with an URL that can be used to sign into the server, in lieu of a normal sign in process.
+        x-nullable: false
     phoneSignInEnabled:
         type: boolean
         default: false
         description: |
             **Can only be set by an administrator.** If enabled, the user will be able to trigger an SMS message which contains a token that can be used to sign in to the server, in lieu of a normal sign in process.
+        x-nullable: false
     reauthenticationEnabled:
         type: boolean
         default: false
         description: |
             **Can only be set by an administrator.** Enable or disable the ability to issue a reauthentication token in a session, and call the reauthentication APIs to issue a new session. 
+        x-nullable: false
     externalIdRequiredOnSignup:
         type: boolean
         default: false
         description: |
             **Can only be set by an administrator.** Should the external ID be required on sign up? If this is true and external ID validation is enabled, this study can support lab codes (where the username and password are auto-generated from the external ID and the user only needs to enter a code).
+        x-nullable: false
     verifyChannelOnSignInEnabled:
         type: boolean
         default: true
         description: |
             **Can only be changed by an administrator.** Should the the credential that is submitted during sign-in 
             be verified? This is always true (with the exception of legacy studies) and should not be changed.
+        x-nullable: false
     accountLimit:
         type: integer
         default: 0
         description: |
             **Can only be set by an administrator.** If not zero, sets an upper-bound limit on the number of accounts that can be created for this study. Once this number is reached, no more sign ups or user creation can occur.
+        x-nullable: false
     disableExport:
         type: boolean
         default: false
         description: |
             If set this field to true, Bridge Exporter will not export this study at all during exporting.
+        x-nullable: false
     minSupportedAppVersions:
         type: object
         description: |
             Minimum supported app versions (older versions will be blocked), keyed by the name of the operating system (we expect either "Android" or "iPhone OS" in the User-Agent header of all requests sent to the server). Example: `{"iPhone OS":14,"Android":10}` 
         additionalProperties:
             type: integer
+        x-nullable: false
     oAuthProviders:
         type: object
         description: |
             The metadata to contact OAuth providers for the Authorization Code Grant Flow.
         additionalProperties:
             $ref: ./oauth_provider.yml
+        x-nullable: false
     pushNotificationARNs:
         type: object
         description: |
             A map between operating system names, and the platform ARN necessary to register a device to receive mobile push notifications. The operating system names are currently "Android" and "iPhone OS". The ARN (Amazon Resource Name) is the name of the Application/platform ARN defined in SNS (currently this must be done by a Bridge administrator).
         additionalProperties:
             type: string
+        x-nullable: false
     appleAppLinks:
         type: array
         description: |
             The entries this study contributes to the `/.well-known/apple-app-site-association` file to enable universal links for iOS apps that use this study as the data store.
         items:
             $ref: ./apple_app_link.yml
+        x-nullable: false
     androidAppLinks:
         type: array
         description: |
             The entries this study contributes to the `/.well-known/assetlinks.json` file to enable app links for Android apps that use this study as the data store.
         items:
             $ref: ./android_app_link.yml
+        x-nullable: false
     resetPasswordSmsTemplate:
         $ref: ./sms_template.yml
         description: Message sent to user with a link to a page where password can be reset. Template variable ${url} is required (depending on whether you wish to promp the user to reset a password or sign in using this account, or both).
+        x-nullable: false
     phoneSignInSmsTemplate:
         $ref: ./sms_template.yml
         description: Message sent to user with a code to validate through the application. Template variable ${token} is required.
+        x-nullable: false
     appInstallLinkSmsTemplate:
         $ref: ./sms_template.yml
         description: Message sent to the user after submitting an intent to participate, directing the user to an appstore link to download your app. Template variable ${appInstallUrl} is required.
+        x-nullable: false
     verifyPhoneSmsTemplate:
         $ref: ./sms_template.yml
         description: Message sent to user with a code to verify a phone number through the application. Template variable ${token} is required.
+        x-nullable: false
     accountExistsSmsTemplate:
         $ref: ./sms_template.yml
         description: Message sent to user if the user tries to sign up with an existing phone number. Template variable ${passwordResetUrl} or ${token} is required.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Study"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/study_and_users.yml
+++ b/rest-api/src/main/resources/definitions/study_and_users.yml
@@ -11,16 +11,20 @@ properties:
         description: A list of Synapse admin user IDs.
         items:
             type: string 
+        x-nullable: false
     study:
         type: string
         description: A label to show the user for this activity.
         $ref: ./study.yml
+        x-nullable: false
     users:
         type: array
         description: A list of users in the new Study.
         items:
             $ref: ./study_participant.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "StudyAndUsers"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/study_consent.yml
+++ b/rest-api/src/main/resources/definitions/study_consent.yml
@@ -7,17 +7,18 @@ description: |
     **Note:** calls that return lists of these study consents do not populate the `documentContent` property. You must retrieve an individual study consent to get the content of the consent.
 required:
     - subpopulationGuid
-    - createdOn
     - documentContent
 properties:
     subpopulationGuid:
         type: string
         description: The guid of the subpopulation to which this consent belongs.
+        x-nullable: false
     createdOn:
         type: string
         format: date-time
         description: |
             The time the document was created on the server. Each update of the consent document creates a new revision at a new `createdOn` timestamp.
+        x-nullable: false
     documentContent:
         type: string
         description: |
@@ -31,7 +32,9 @@ properties:
             |${sponsorName}|The name of the sponsor for this study (the institution or research team name)|
 
             The signature block will be appended to the end of your consent document. **It is not possible to remove or change the signature block at this time.**
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "StudyConsent"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/study_identifier.yml
+++ b/rest-api/src/main/resources/definitions/study_identifier.yml
@@ -5,6 +5,7 @@ required:
 properties:
     identifier:
         type: string
+        readOnly: true
         description: The study's identifier (unique to the study).
     type:
         type: string

--- a/rest-api/src/main/resources/definitions/study_identifier.yml
+++ b/rest-api/src/main/resources/definitions/study_identifier.yml
@@ -7,7 +7,9 @@ properties:
         type: string
         readOnly: true
         description: The study's identifier (unique to the study).
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "StudyIdentifier"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/study_identifier.yml
+++ b/rest-api/src/main/resources/definitions/study_identifier.yml
@@ -1,7 +1,5 @@
 description: A typesafe representation of a study's string identifier
 type: object
-required:
-    - identifier
 properties:
     identifier:
         type: string

--- a/rest-api/src/main/resources/definitions/study_participant.yml
+++ b/rest-api/src/main/resources/definitions/study_participant.yml
@@ -2,8 +2,6 @@ allOf:
     - $ref: ./abstract_study_participant.yml
     - description: |
         The full record about a study participant.
-    - required:
-        - consentHistories
     - properties:
         healthCode:
             type: string

--- a/rest-api/src/main/resources/definitions/study_participant.yml
+++ b/rest-api/src/main/resources/definitions/study_participant.yml
@@ -24,10 +24,12 @@ allOf:
                 type: array
                 items:
                     $ref: ../definitions/user_consent_history.yml
+            x-nullable: false
         consented:
             description: |
                 True if the user has consented to all required consents, based on the user's most recent request info (client info, languages, data groups). May be null if this object was not constructed with consent histories, or if consent status is indeterminate.
             type: boolean
+            x-nullable: false
         timeZone:
             type: string
             description: User's original time zone, as measured by the timezone used to request activities, as a string offset in ISO8601 format.
@@ -35,3 +37,4 @@ allOf:
             type: string
             readOnly: true
             description: "StudyParticipant"
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/subpopulation.yml
+++ b/rest-api/src/main/resources/definitions/subpopulation.yml
@@ -20,9 +20,11 @@ properties:
         type: string
         description: |
             A unique auto-generated identifier for the subpopulation. Usually a GUID (but not always). Cannot be changed after creation. Used to retrieve the published consent for this subpopulation.
+        x-nullable: false
     name:
         type: string
         description: The name of this subpopulation.
+        x-nullable: false
     description:
         type: string
         description: The description of this subpopulation.
@@ -30,48 +32,59 @@ properties:
         $ref: ./criteria.yml
         description: |
             Optional selection criteria that can be used to determine if a user should be assigned to this subpopulation or not. If the user does not match a subpopulation, then that subpopulation and its requirements are invisible to that user. Otherwise the user is in the subpopulation and all its consent requirements apply.
+        x-nullable: false
     autoSendConsentSuppressed:
         type: boolean
         default: false
         description: |
             Should the user automatically be sent (via email or SMS) a copy of the consent when they sign it?
+        x-nullable: false
     required:
         type: boolean
         description: |
             If true, participants must sign the consent associated with this subpopulation if they are identified as a member of this subpopulation. Users will receive a 412 response from Bridge if this condition is not met.
+        x-nullable: false
     defaultGroup:
         type: boolean
         description: |
             If true, this is the default subpopulation created for a study, and it cannot be deleted (although it can be changed, and even made optional or hidden through the use of criteria).
+        x-nullable: false
     publishedConsentCreatedOn:
         type: string
         format: date-time
         description: |
             The creation date (ISO 8601 timestamp) of the version of the consent agreement for this subpopulation that is published, ie. that is presented to users for their signature. The subpopulation guid and this createdOn timestamp can be used to retrieve the consent document.
+        x-nullable: false
     dataGroupsAssignedWhileConsented:
         type: array
         description: The data groups that will be assigned to a participant who consents to membership in this subpopulation. If the participant withdraws from this subpopulation, the data groups will be removed from their account.
         items:
             type: string
+        x-nullable: false
     substudyIdsAssignedOnConsent:
         type: array
         description: The substudies this participant is associated to when they consent to membership in this subpopulation. This association is permanent (even if the participant withdraws from the subpopulation, they are still part of the substudy, visible to substudy research administrations, and so forth).
         items:
             type: string
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: | 
             The optimistic locking version of the survey. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring.
+        x-nullable: false
     consentHTML:
         type: string
         description: |
             The URL to retrieve an HTML version of the published and active version of the consent. This can be referenced in your mobile app, web site, etc. Publishing a new consent revision will update this document.
+        x-nullable: false
     consentPDF:
         type: string
         description: |
             The URL to retrieve a PDF version of the published and active version of the consent. This can be referenced in your mobile app, web site, etc. Publishing a new consent revision will update this document.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Subpopulation"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/subscription_request.yml
+++ b/rest-api/src/main/resources/definitions/subscription_request.yml
@@ -13,3 +13,4 @@ properties:
         type: string
         readOnly: true
         description: "SubscriptionRequest"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/subscription_status.yml
+++ b/rest-api/src/main/resources/definitions/subscription_status.yml
@@ -1,10 +1,6 @@
 type: object
 description: |
     A participant will receive one of these records for every topic in a study, indicating whether or not the participant is subscribed to that topic. The list of topics can be used to show the user a UI to change these subscriptions.
-required:
-    - topicGuid
-    - topicName
-    - subscribed
 properties:
     topicGuid:
         type: string

--- a/rest-api/src/main/resources/definitions/subscription_status.yml
+++ b/rest-api/src/main/resources/definitions/subscription_status.yml
@@ -9,13 +9,17 @@ properties:
     topicGuid:
         type: string
         readOnly: true
+        x-nullable: false
     topicName:
         type: string
         readOnly: true
+        x-nullable: false
     subscribed:
         type: boolean
         readOnly: true
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "SubscriptionStatus"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/substudy.yml
+++ b/rest-api/src/main/resources/definitions/substudy.yml
@@ -37,3 +37,8 @@ properties:
         description: |
             The optimistic locking version of the sub-study. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring. It can also serve as a key to determine if a local cache of this `Substudy` revision needs to be updated.
         x-nullable: false
+    type:
+        type: string
+        readOnly: true
+        description: "Substudy"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/substudy.yml
+++ b/rest-api/src/main/resources/definitions/substudy.yml
@@ -9,25 +9,31 @@ properties:
     id:
         type: string
         description: The identifier for this sub-study.
+        x-nullable: false
     name:
         type: string
         description: The name of the sub-study.
+        x-nullable: false
     deleted:
         type: boolean
         description: |
             Has this sub-study been logically deleted (an admin can restore it)?
+        x-nullable: false
     createdOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time the app config was created.
+        x-nullable: false
     modifiedOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time the app config was last modified.
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The optimistic locking version of the sub-study. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring. It can also serve as a key to determine if a local cache of this `Substudy` revision needs to be updated.
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/survey.yml
+++ b/rest-api/src/main/resources/definitions/survey.yml
@@ -9,6 +9,7 @@ required:
 properties:
     guid:
         type: string
+        x-nullable: false
     moduleId:
         type: string
         description: Module ID, if this survey was imported from a shared module.
@@ -19,15 +20,18 @@ properties:
         type: string
         description: |
             The name of this survey. The name can be changed after creation, and should not appear in the UI.
+        x-nullable: false
     identifier:
         type: string
         description: |
             A private name for the survey, only visible to researchers, used to identify the survey on export. It is recommended (but not required) that this identifier be unique for this survey type within this study.
+        x-nullable: false
     published:
         type: boolean
         readOnly: true
         description: |
             True if this survey revision has been published, and is accessible to users through scheduling. More than one version of a survey may be published; it is most common to return the most recently published version to users.
+        x-nullable: false
     schemaRevision:
         type: integer
         format: int64
@@ -37,11 +41,13 @@ properties:
         type: string
         format: date-time
         description: The ISO 8601 date on which this version of this survey was created.
+        x-nullable: false
     modifiedOn:
         type: string
         format: date-time
         readOnly: true
         description: The date and time when this version of the survey was last modified.
+        x-nullable: false
     copyrightNotice:
         type: string
         description: |
@@ -49,11 +55,13 @@ properties:
     deleted:
         type: boolean
         description: Has this survey been logically deleted (an admin can restore it)?
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The version of this survey as used to implement optimistic locking. This must be passed back to the server on an update, unmodified, in order for the update to succeed. If the survey has been concurrently modified, the update will throw an error.
+        x-nullable: false
     elements:
         type: array
         description: |
@@ -61,7 +69,9 @@ properties:
         items:
             discriminator: type
             $ref: ./survey_element.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Survey"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/survey_element.yml
+++ b/rest-api/src/main/resources/definitions/survey_element.yml
@@ -4,9 +4,6 @@ discriminator: type
 required:
     - guid
     - identifier
-    - type
-    - beforeRules
-    - afterRules
 properties:
     guid:
         type: string

--- a/rest-api/src/main/resources/definitions/survey_element.yml
+++ b/rest-api/src/main/resources/definitions/survey_element.yml
@@ -11,21 +11,26 @@ properties:
     guid:
         type: string
         description: A unique GUID for this element of the survey
+        x-nullable: false
     beforeRules:
         type: array
         description: |
             Survey elements can include one or more rules about how to progress through the elements of a survey (e.g. skipping a question if the user has been assigned to a specific data group). These rules are evaluated before the current element and may prevent it from being displayed. See [Survey Rule](#SurveyRule) for more information.
         items:
             $ref: ./survey_rule.yml
+        x-nullable: false
     afterRules:
         type: array
         description: |
             Survey elements can include one or more rules about how to progress through the elements of a survey (e.g. skipping some questions if they are not relevant to the participant, based on an answer to a question). These rules are evaluated after the user answers the current survey question. See [Survey Rule](#SurveyRule) for more information.
         items:
             $ref: ./survey_rule.yml
+        x-nullable: false
     identifier:
         type: string
         description: |
             A unique and easy-to-remember identifier, assigned by a researcher, that is maintained through later versions of the survey.
+        x-nullable: false
     type:
         type: string
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/survey_info_screen.yml
+++ b/rest-api/src/main/resources/definitions/survey_info_screen.yml
@@ -22,3 +22,9 @@ allOf:
         image:
             description: An optional Image element describing an image to show for this screen.
             $ref: ./image.yml
+        type:
+            type: string
+            readOnly: true
+            description: "SurveyInfoScreen"
+            x-nullable: false
+

--- a/rest-api/src/main/resources/definitions/survey_info_screen.yml
+++ b/rest-api/src/main/resources/definitions/survey_info_screen.yml
@@ -6,14 +6,15 @@ allOf:
     - required:
         - title
         - prompt
-        - type
     - properties:
         title:
             type: string
             description: A title for this screen.
+            x-nullable: false
         prompt:
             type: string
             description: The main instructions or information text for the user
+            x-nullable: false
         promptDetail:
             type: string
             description: |

--- a/rest-api/src/main/resources/definitions/survey_question.yml
+++ b/rest-api/src/main/resources/definitions/survey_question.yml
@@ -12,15 +12,19 @@ allOf:
             type: string
             description: |
                 A title for this question. Although this is required, it may or may not be used in the interface. 
+            x-nullable: false
         prompt:
             type: string
             description: |
                 The question proper.
+            x-nullable: false
         promptDetail:
             type: string
             description: |
                 Sub-question text that provides further instructions or clarifications on how to answer.
         uiHint:
             $ref: ./enums/ui_hint.yml
+            x-nullable: false
         constraints:
             $ref: ./constraints/constraints.yml
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/survey_question_option.yml
+++ b/rest-api/src/main/resources/definitions/survey_question_option.yml
@@ -7,6 +7,7 @@ properties:
     label:
         type: string
         description: The text to show in the UI (must be plain text).
+        x-nullable: false
     detail:
         type: string
         description: |
@@ -23,3 +24,4 @@ properties:
         type: string
         readOnly: true
         description: "SurveyQuestionOption"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/survey_reference.yml
+++ b/rest-api/src/main/resources/definitions/survey_reference.yml
@@ -7,19 +7,24 @@ properties:
     identifier:
         type: string
         description: The survey identifier.
+        x-nullable: false
     guid:
         type: string
         description: The survey guid
+        x-nullable: false
     createdOn:
         type: string
         format: date-time
         description: |
             The createdOn timestamp of the version of the survey. This can be null, which indicates the most recently published version of the study should be used.
+        x-nullable: false
     href:
         type: string
         readOnly: true
         description: An URL to retrieve the survey.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "SurveyReference"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/survey_rule.yml
+++ b/rest-api/src/main/resources/definitions/survey_rule.yml
@@ -12,8 +12,6 @@ description: |
 type: object
 required:
     - operator
-    - value
-    - dataGroups
 properties:
     operator:
         $ref: ./enums/operator.yml
@@ -40,17 +38,14 @@ properties:
         type: boolean
         description: |
             If specified, and the rule's expression is true, immediately stop evaluating rules and end the survey. The users existing answers to the survey should be sent to the server.
-        x-nullable: false
     displayIf:
         type: boolean
         description: |
             **Before rules only.** If the rule expression is true, display this question or information screen.
-        x-nullable: false
     displayUnless:
         type: boolean
         description: |
             **Before rules only.** If the rule expression is true, do not display this question or information. Put differently, show the screen unless the expression is true.
-        x-nullable: false
     assignDataGroup:
         type: string
         description: |

--- a/rest-api/src/main/resources/definitions/survey_rule.yml
+++ b/rest-api/src/main/resources/definitions/survey_rule.yml
@@ -17,6 +17,7 @@ required:
 properties:
     operator:
         $ref: ./enums/operator.yml
+        x-nullable: false
     value:
         type: string
         description: |
@@ -30,6 +31,7 @@ properties:
             type: string
         description: |
             Some operators will test a set of data groups against the user's set of data groups. The operators `any` and `all` make a comparison of the sets in this property against the user's data groups.
+        x-nullable: false
     skipTo:
         type: string
         description: |
@@ -38,14 +40,17 @@ properties:
         type: boolean
         description: |
             If specified, and the rule's expression is true, immediately stop evaluating rules and end the survey. The users existing answers to the survey should be sent to the server.
+        x-nullable: false
     displayIf:
         type: boolean
         description: |
             **Before rules only.** If the rule expression is true, display this question or information screen.
+        x-nullable: false
     displayUnless:
         type: boolean
         description: |
             **Before rules only.** If the rule expression is true, do not display this question or information. Put differently, show the screen unless the expression is true.
+        x-nullable: false
     assignDataGroup:
         type: string
         description: |
@@ -54,3 +59,4 @@ properties:
         type: string
         readOnly: true
         description: "SurveyRule"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/task_reference.yml
+++ b/rest-api/src/main/resources/definitions/task_reference.yml
@@ -8,9 +8,11 @@ properties:
         type: string
         description: |
             The identifier that defines a task on the client. Note that this value is conventional; it needs to be defined for a study but has no further meaning on the server. 
+        x-nullable: false
     schema:
         $ref: ./schema_reference.yml
     type:
         type: string
         readOnly: true
         description: "TaskReference"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload.yml
+++ b/rest-api/src/main/resources/definitions/upload.yml
@@ -9,49 +9,61 @@ required:
 properties:
     uploadId:
         type: string
+        readOnly: true
         description: The GUID assigned to this upoad.
     schemaId:
         type: string
+        readOnly: true
         description: The ID of the schema for this upload.
     schemaRevision:
         type: integer
+        readOnly: true
         format: int64
         description: The revision for the schema of this upload.
     recordId:
         type: string
+        readOnly: true
         description: The record ID of the upload in Synapse.
     healthData:
         $ref: ./health_data_record.yml
+        readOnly: true
     contentLength:
         type: integer
+        readOnly: true
         format: int64
         description: |
             The size of the object in bytes. A standard HTTP header. For more information, go to [http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13)
     status:
         $ref: ./enums/upload_status.yml
+        readOnly: true
     requestedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The date and time (ISO 8601 format) that the client requested an URL to make an upload to the server.
     completedOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The date and time (ISO 8601 format) that the upload was completed.
     completedBy:
         type: string
+        readOnly: true
         description: |
             Currently the API has an endpoint for the client to call and mark an upload completed. However, there is also a process that detects uploads to S3 and marks the uploads complete. This field indicates which client completed the upload.
         enum: [app, s3_worker]
     validationMessageList:
         type: array
+        readOnly: true
         description: |
             An array of error messages if this upload did not pass validation.
         items:
             type: string
     healthRecordExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/upload.yml
+++ b/rest-api/src/main/resources/definitions/upload.yml
@@ -11,6 +11,7 @@ properties:
         type: string
         readOnly: true
         description: The GUID assigned to this upoad.
+        x-nullable: false
     schemaId:
         type: string
         readOnly: true
@@ -36,12 +37,14 @@ properties:
     status:
         $ref: ./enums/upload_status.yml
         readOnly: true
+        x-nullable: false
     requestedOn:
         type: string
         readOnly: true
         format: date-time
         description: |
             The date and time (ISO 8601 format) that the client requested an URL to make an upload to the server.
+        x-nullable: false
     completedOn:
         type: string
         readOnly: true
@@ -61,10 +64,13 @@ properties:
             An array of error messages if this upload did not pass validation.
         items:
             type: string
+        x-nullable: false
     healthRecordExporterStatus:
         $ref: ./enums/synapse_exporter_status.yml
         readOnly: true
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "Upload"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload_field_definition.yml
+++ b/rest-api/src/main/resources/definitions/upload_field_definition.yml
@@ -9,12 +9,15 @@ properties:
     name:
         type: string
         description: Field name. A schema cannot contain fields with the same name.
+        x-nullable: false
     required:
         type: boolean
         default: true
         description: Whether this field is required.
+        x-nullable: false
     type:
         $ref: ./enums/upload_field_type.yml
+        x-nullable: false
     allowOtherChoices:
         type: boolean
         description: |
@@ -41,6 +44,7 @@ properties:
             For schemas generated from surveys, this list will be the "value" in the survey question option, or the "label" if value is not specified.
         items:
             type: string
+        x-nullable: false
     unboundedText:
         type: boolean
         description: |

--- a/rest-api/src/main/resources/definitions/upload_request.yml
+++ b/rest-api/src/main/resources/definitions/upload_request.yml
@@ -26,3 +26,4 @@ properties:
         type: string
         readOnly: true
         description: "UploadRequest"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload_schema.yml
+++ b/rest-api/src/main/resources/definitions/upload_schema.yml
@@ -16,12 +16,14 @@ properties:
             A map of operating system names to minimum app versions. The user must send a `User-Agent` header in a prescribed format, that declares the app version to be equal to or less than this version number, in order to match.
         additionalProperties:
             type: integer
+        x-nullable: false
     minAppVersions:
         type: object
         description: |
             A map of operating system names to minimum app versions. The user must send a `User-Agent` header in a prescribed format, that declares the app version to be equal to or greater than this version number, in order to match.
         additionalProperties:
             type: integer
+        x-nullable: false
     moduleId:
         type: string
         description: Module ID, if this schema was imported from a shared module.
@@ -31,11 +33,13 @@ properties:
     name:
         type: string
         description: User-friendly schema name.
+        x-nullable: false
     revision:
         type: integer
         format: int64
         description: |
             Revision number of the schema, used to distinguish versions of the same data format. This should be blank when creating a schema, and it should be passed back to the server when updating. If the schema revision cannot be updated in a backwards-compatible fashion, the server will throw an exception. You will need to increment the revision number and create a new revision of the schema.
+        x-nullable: false
     schemaId:
         type: string
         description: Unique identifier for the schema.
@@ -47,6 +51,7 @@ properties:
         type: string
         description: |
             **Only available through worker APIs.** The identifier of the study from which this schema was retrieved.
+        x-nullable: false
     surveyCreatedOn:
         type: string
         format: date-time
@@ -55,18 +60,23 @@ properties:
             (in ISO 8601 format) of the survey it represents.
     schemaType:
         $ref: ./enums/upload_schema_type.yml
+        x-nullable: false
     deleted:
         type: boolean
+        x-nullable: false
     version:
         type: integer
         format: int64
         description: |
             The optimistic locking version of the survey. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring.
+        x-nullable: false
     fieldDefinitions:
         type: array
         items:
             $ref: ./upload_field_definition.yml
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "UploadSchema"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload_schema.yml
+++ b/rest-api/src/main/resources/definitions/upload_schema.yml
@@ -6,8 +6,6 @@ required:
     - revision
     - schemaId
     - version
-    - minAppVersions
-    - maxAppVersions
     - fieldDefinitions
 properties:
     maxAppVersions:
@@ -49,6 +47,7 @@ properties:
             If this schema is created from a survey, this is the GUID of the survey it represents.
     studyId:
         type: string
+        readOnly: true
         description: |
             **Only available through worker APIs.** The identifier of the study from which this schema was retrieved.
         x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload_session.yml
+++ b/rest-api/src/main/resources/definitions/upload_session.yml
@@ -24,3 +24,4 @@ properties:
         type: string
         readOnly: true
         description: "UploadSession"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload_session.yml
+++ b/rest-api/src/main/resources/definitions/upload_session.yml
@@ -1,25 +1,24 @@
 type: object
-required:
-    - id
-    - url
-    - expires
 properties:
     id:
         type: string
         readOnly: true
         description: |
             The upload ID. The client needs to use this ID to call Bridge when the upload is complete.
+        x-nullable: false
     url:
         type: string
         readOnly: true
         description: |
             A pre-signed URL for doing a PUT upload of the data. The URL will remain valid for 24 hours once created on the Bridge side.
+        x-nullable: false
     expires:
         type: string
         readOnly: true
         format: date-time
         description: |
             The ISO 8601 date and time stamp at which this session will expire.
+        x-nullable: false
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/upload_session.yml
+++ b/rest-api/src/main/resources/definitions/upload_session.yml
@@ -6,14 +6,17 @@ required:
 properties:
     id:
         type: string
+        readOnly: true
         description: |
             The upload ID. The client needs to use this ID to call Bridge when the upload is complete.
     url:
         type: string
+        readOnly: true
         description: |
             A pre-signed URL for doing a PUT upload of the data. The URL will remain valid for 24 hours once created on the Bridge side.
     expires:
         type: string
+        readOnly: true
         format: date-time
         description: |
             The ISO 8601 date and time stamp at which this session will expire.

--- a/rest-api/src/main/resources/definitions/upload_validation_status.yml
+++ b/rest-api/src/main/resources/definitions/upload_validation_status.yml
@@ -5,17 +5,21 @@ required:
 properties:
     id:
         type: string
+        readOnly: true
         description: The identifier for this upload.
     messageList:
         type: array
+        readOnly: true
         description: |
             An array of error messages if failures occurred during validation.
         items:
             type: string
     status:
         $ref: ./enums/upload_status.yml
+        readOnly: true
     record:
         $ref: ./health_data_record.yml
+        readOnly: true
     type:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/upload_validation_status.yml
+++ b/rest-api/src/main/resources/definitions/upload_validation_status.yml
@@ -1,12 +1,11 @@
 type: object
 readOnly: true
-required:
-    - messageList
 properties:
     id:
         type: string
         readOnly: true
         description: The identifier for this upload.
+        x-nullable: false
     messageList:
         type: array
         readOnly: true
@@ -14,9 +13,11 @@ properties:
             An array of error messages if failures occurred during validation.
         items:
             type: string
+        x-nullable: false
     status:
         $ref: ./enums/upload_status.yml
         readOnly: true
+        x-nullable: false
     record:
         $ref: ./health_data_record.yml
         readOnly: true
@@ -24,3 +25,4 @@ properties:
         type: string
         readOnly: true
         description: "UploadValidationStatus"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/upload_validation_status.yml
+++ b/rest-api/src/main/resources/definitions/upload_validation_status.yml
@@ -1,5 +1,4 @@
 type: object
-readOnly: true
 properties:
     id:
         type: string
@@ -9,8 +8,7 @@ properties:
     messageList:
         type: array
         readOnly: true
-        description: |
-            An array of error messages if failures occurred during validation.
+        description: An array of error messages if failures occurred during validation.
         items:
             type: string
         x-nullable: false

--- a/rest-api/src/main/resources/definitions/user_consent_history.yml
+++ b/rest-api/src/main/resources/definitions/user_consent_history.yml
@@ -7,15 +7,18 @@ properties:
         type: string
         readOnly: true
         description: The consent group that the participant agreed to participate in.
+        x-nullable: false
     consentCreatedOn:
         type: string
         readOnly: true
         format: date-time
         description: ISO 8601 date and time that the consent was created on.
+        x-nullable: false
     name:
         type: string
         readOnly: true
         description: Full name as entered by the participant.
+        x-nullable: false
     birthdate:
         type: string
         readOnly: true
@@ -34,6 +37,7 @@ properties:
         readOnly: true
         format: date-time
         description: ISO 8601 date and time that the consent was signed by the user.
+        x-nullable: false
     withdrewOn:
         type: string
         readOnly: true
@@ -45,7 +49,9 @@ properties:
         readOnly: true
         description: |
             True if the user signed the most recently published version of the consent, false otherwise.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "UserConsentHistory"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/user_consent_history.yml
+++ b/rest-api/src/main/resources/definitions/user_consent_history.yml
@@ -5,35 +5,44 @@ type: object
 properties:
     subpopulationGuid:
         type: string
+        readOnly: true
         description: The consent group that the participant agreed to participate in.
     consentCreatedOn:
         type: string
+        readOnly: true
         format: date-time
         description: ISO 8601 date and time that the consent was created on.
     name:
         type: string
+        readOnly: true
         description: Full name as entered by the participant.
     birthdate:
         type: string
+        readOnly: true
         format: date
         description: ISO 8601 date string (e.g. "YYYY-MM-DD").
     imageData:
         type: string
+        readOnly: true
         description: The signature image in a base 64 encoding.
     imageMimeType:
         type: string
+        readOnly: true
         description: The IANA mime type indicator for the image (e.g. "image/png").
     signedOn:
         type: string
+        readOnly: true
         format: date-time
         description: ISO 8601 date and time that the consent was signed by the user.
     withdrewOn:
         type: string
+        readOnly: true
         format: date-time
         description: |
             ISO 8601 date and time that the user withdrew the consent, if the user withdrew from the study (note that later consent records may re-enroll the user in the study; nothing prevents users from joining and quitting the study multiple times).
     hasSignedActiveConsent:
         type: boolean
+        readOnly: true
         description: |
             True if the user signed the most recently published version of the consent, false otherwise.
     type:

--- a/rest-api/src/main/resources/definitions/user_consent_history.yml
+++ b/rest-api/src/main/resources/definitions/user_consent_history.yml
@@ -1,6 +1,4 @@
-description: | 
-    A record of a complete consent (including both the dates of consent and withdrawal, if applicable);
-readOnly: true
+description: A record of a complete consent (including both the dates of consent and withdrawal, if applicable);
 type: object
 properties:
     subpopulationGuid:

--- a/rest-api/src/main/resources/definitions/user_profile.yml
+++ b/rest-api/src/main/resources/definitions/user_profile.yml
@@ -18,3 +18,4 @@ properties:
         type: string
         readOnly: true
         description: "UserProfile"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/user_profile.yml
+++ b/rest-api/src/main/resources/definitions/user_profile.yml
@@ -1,9 +1,6 @@
 type: object
 description: |
     An early user information object that has been superceded by the [StudyParticipant](#StudyParticipant) object, along with a new set of API endpoints (`/v3/participants/self`).
-required:
-    - email
-    - username
 properties:
     firstName:
         type: string
@@ -13,6 +10,7 @@ properties:
         type: string
     username:
         type: string
+        readOnly: true
         description: Now always the same value as the user's email address
     type:
         type: string

--- a/rest-api/src/main/resources/definitions/user_session_info.yml
+++ b/rest-api/src/main/resources/definitions/user_session_info.yml
@@ -1,38 +1,134 @@
 readOnly: true
 allOf:
-    - $ref: ./abstract_study_participant.yml
     - description: |
-        Information about the user and their session.
+        Information about the user and their session. This information cannot be updated; to update a user's record, use the StudyParticipant record and APIs.
     - type: object
     - properties:
+        firstName:
+            type: string
+            readOnly: true
+            description: First name (given name) of the user.
+        lastName:
+            type: string
+            readOnly: true
+            description: Last name (family name) of the user.
+        externalId:
+            type: string
+            readOnly: true
+            description: |
+                An externally-assignable identifier a research partner can use to re-identify a user's data in the exported data set (this must be provided by the application, it is not created by Bridge). It is a string that can be set or updated to any value without constraints, unless Bridge is configured to manage the study's external IDs. Then the ID must be submitted on sign up, and cannot be modified afterward.
+        id:
+            type: string
+            readOnly: true
+            description: |
+                An ID assigned to this account by Bridge system. This ID is exposed in the API and is different from the health code assigned to the user's anonymized data. Bridge never exports this ID along with the health code from Bridge.  
+        notifyByEmail:
+            type: boolean
+            readOnly: true
+            default: true
+            description: |
+                True if the user has consented to be contacted via email outside the application, false otherwise.
+        attributes:
+            type: object
+            readOnly: true
+            additionalProperties:
+                type: string
+            description: |
+                A map of user profile attributes that have been set for this user (the attributes themselves must be specified in the study's configuration, and the values are stored encrypted in case they capture personally-identifying information).
+        sharingScope:
+            $ref: ./enums/sharing_scope.yml
+            readOnly: true
+        createdOn:
+            type: string
+            format: date-time
+            readOnly: true
+            description: The date and time the account was created.
+        emailVerified:
+            type: boolean
+            readOnly: true
+            description: Has the user verified that they have control of this email address?
+        phoneVerified:
+            type: boolean
+            readOnly: true
+            description: Has the user verified that they have control of this phone number?
+        status:
+            $ref: ./enums/account_status.yml
+            readOnly: true
+        roles:
+            type: array
+            readOnly: true
+            items:
+                $ref: ./enums/role.yml
+        dataGroups:
+            type: array
+            readOnly: true
+            description: |
+                The data groups set for this user. Data groups must be strings that are defined in the list of all valid data groups for the study, as part of the study object. 
+            items:
+                type: string
+        clientData:
+            type: object
+            readOnly: true
+            description: |
+                Client data for a user should be in a syntactically valid JSON format. It will be returned as is to the client (as JSON).
+            additionalProperties: true
+        languages:
+            type: array
+            readOnly: true
+            description: |
+                Two letter language codes to assign to this user (these are initially retrieved from the user's `Accept-Language` header and then persisted as part of account configuration). 
+            items:
+                type: string
+        substudyIds:
+            type: array
+            readOnly: true
+            description: The substudies this participant is associated to.
+            items:
+                type: string
+        externalIds:
+            type: object
+            readOnly: true
+            description: The exernal IDs this participant is associated to, mapped to the substudy that issued the external ID. Typically a user signs up with the external ID, and is assigned to that substudy as a result.
+            additionalProperties:
+                type: string
         authenticated:
             type: boolean
+            readOnly: true
             description: Is the user currently authenticated?
         sessionToken:
             type: string
+            readOnly: true
             description: The session token that must be returned to the server to access services requiring authentication.
         reauthToken:
             type: string
+            readOnly: true
             description: |
                 A token, supplied when a new session is returned, that can be used to refresh the session at a later time. The API to reauthenticate with the token will refresh your session token and reset the session's timeout value. The reauthentication token can only be used one time. 
         environment:
             $ref: ./enums/environment.yml
+            readOnly: true
         email:
             type: string
+            readOnly: true
             description: The user's email.
         phone:
             $ref: ./phone.yml
+            readOnly: true
         dataSharing:
             type: boolean
+            readOnly: true
             description: True if the sharing scope is anything other than "no_sharing".
         signedMostRecentConsent:
             type: boolean
+            readOnly: true
             description: True if all *required* consents have been signed and the versions signed are the most up-to-date versions of those consents.
         consented:
             type: boolean
+            readOnly: true
             description: True if all required consents have been signed.
         consentStatuses:
             type: object
+            readOnly: true
             description: |
                 A mapping from a subpopulation GUID to information about the participant's consent status in that subpopulation (whether consented or not). Only the subpopulations that currently apply to this user will have a ConsentStatus object in the map.
             additionalProperties:

--- a/rest-api/src/main/resources/definitions/user_session_info.yml
+++ b/rest-api/src/main/resources/definitions/user_session_info.yml
@@ -22,12 +22,14 @@ allOf:
             readOnly: true
             description: |
                 An ID assigned to this account by Bridge system. This ID is exposed in the API and is different from the health code assigned to the user's anonymized data. Bridge never exports this ID along with the health code from Bridge.  
+            x-nullable: false
         notifyByEmail:
             type: boolean
             readOnly: true
             default: true
             description: |
                 True if the user has consented to be contacted via email outside the application, false otherwise.
+            x-nullable: false
         attributes:
             type: object
             readOnly: true
@@ -35,30 +37,37 @@ allOf:
                 type: string
             description: |
                 A map of user profile attributes that have been set for this user (the attributes themselves must be specified in the study's configuration, and the values are stored encrypted in case they capture personally-identifying information).
+            x-nullable: false
         sharingScope:
             $ref: ./enums/sharing_scope.yml
             readOnly: true
+            x-nullable: false
         createdOn:
             type: string
             format: date-time
             readOnly: true
             description: The date and time the account was created.
+            x-nullable: false
         emailVerified:
             type: boolean
             readOnly: true
             description: Has the user verified that they have control of this email address?
+            x-nullable: false
         phoneVerified:
             type: boolean
             readOnly: true
             description: Has the user verified that they have control of this phone number?
+            x-nullable: false
         status:
             $ref: ./enums/account_status.yml
             readOnly: true
+            x-nullable: false
         roles:
             type: array
             readOnly: true
             items:
                 $ref: ./enums/role.yml
+            x-nullable: false
         dataGroups:
             type: array
             readOnly: true
@@ -66,6 +75,7 @@ allOf:
                 The data groups set for this user. Data groups must be strings that are defined in the list of all valid data groups for the study, as part of the study object. 
             items:
                 type: string
+            x-nullable: false
         clientData:
             type: object
             readOnly: true
@@ -79,26 +89,31 @@ allOf:
                 Two letter language codes to assign to this user (these are initially retrieved from the user's `Accept-Language` header and then persisted as part of account configuration). 
             items:
                 type: string
+            x-nullable: false
         substudyIds:
             type: array
             readOnly: true
             description: The substudies this participant is associated to.
             items:
                 type: string
+            x-nullable: false
         externalIds:
             type: object
             readOnly: true
             description: The exernal IDs this participant is associated to, mapped to the substudy that issued the external ID. Typically a user signs up with the external ID, and is assigned to that substudy as a result.
             additionalProperties:
                 type: string
+            x-nullable: false
         authenticated:
             type: boolean
             readOnly: true
             description: Is the user currently authenticated?
+            x-nullable: false
         sessionToken:
             type: string
             readOnly: true
             description: The session token that must be returned to the server to access services requiring authentication.
+            x-nullable: false
         reauthToken:
             type: string
             readOnly: true
@@ -107,6 +122,7 @@ allOf:
         environment:
             $ref: ./enums/environment.yml
             readOnly: true
+            x-nullable: false
         email:
             type: string
             readOnly: true
@@ -118,14 +134,17 @@ allOf:
             type: boolean
             readOnly: true
             description: True if the sharing scope is anything other than "no_sharing".
+            x-nullable: false
         signedMostRecentConsent:
             type: boolean
             readOnly: true
             description: True if all *required* consents have been signed and the versions signed are the most up-to-date versions of those consents.
+            x-nullable: false
         consented:
             type: boolean
             readOnly: true
             description: True if all required consents have been signed.
+            x-nullable: false
         consentStatuses:
             type: object
             readOnly: true
@@ -133,7 +152,9 @@ allOf:
                 A mapping from a subpopulation GUID to information about the participant's consent status in that subpopulation (whether consented or not). Only the subpopulations that currently apply to this user will have a ConsentStatus object in the map.
             additionalProperties:
                 $ref: ../definitions/consent_status.yml
+            x-nullable: false
         type:
             type: string
             readOnly: true
             description: "UserSessionInfo"
+            x-nullable: false

--- a/rest-api/src/main/resources/definitions/verification.yml
+++ b/rest-api/src/main/resources/definitions/verification.yml
@@ -11,3 +11,4 @@ properties:
         type: string
         readOnly: true
         description: "Verification"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/verification.yml
+++ b/rest-api/src/main/resources/definitions/verification.yml
@@ -1,5 +1,4 @@
-description: |
-    A JSON payload to sent the email or phone verification token back to the bridge server.
+description: A payload to sent the email or phone verification token back to the bridge server.
 type: object
 required:
     - sptoken

--- a/rest-api/src/main/resources/definitions/version_holder.yml
+++ b/rest-api/src/main/resources/definitions/version_holder.yml
@@ -1,5 +1,4 @@
-description: |
-    An object that holds the version for a created or updated entity.
+description: An object that holds the version for a created or updated entity.
 type: object
 properties:
     version:

--- a/rest-api/src/main/resources/definitions/version_holder.yml
+++ b/rest-api/src/main/resources/definitions/version_holder.yml
@@ -7,7 +7,9 @@ properties:
         format: int64
         readOnly: true
         description: The optimistic locking version of the entity.
+        x-nullable: false
     type:
         type: string
         readOnly: true
         description: "VersionHolder"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/withdrawal.yml
+++ b/rest-api/src/main/resources/definitions/withdrawal.yml
@@ -10,3 +10,4 @@ properties:
         type: string
         readOnly: true
         description: "Withdrawal"
+        x-nullable: false

--- a/rest-api/src/main/resources/paths/activityevents/v1_activityevents.yml
+++ b/rest-api/src/main/resources/paths/activityevents/v1_activityevents.yml
@@ -17,7 +17,7 @@ post:
         - ActivityEvents
         - _For Consented Users
     parameters:
-        - name: body
+        - name: CustomActivityEventRequest
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/notifications/v3_notifications.yml
+++ b/rest-api/src/main/resources/paths/notifications/v3_notifications.yml
@@ -34,7 +34,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: NotificationRegistration
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/notifications/v3_notifications_guid.yml
+++ b/rest-api/src/main/resources/paths/notifications/v3_notifications_guid.yml
@@ -35,7 +35,7 @@ post:
         -   BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: NotificationRegistration
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/notifications/v3_notifications_guid_subscriptions.yml
+++ b/rest-api/src/main/resources/paths/notifications/v3_notifications_guid_subscriptions.yml
@@ -34,7 +34,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: SubscriptionRequest
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/oauth/v3_oauth_vendorId.yml
+++ b/rest-api/src/main/resources/paths/oauth/v3_oauth_vendorId.yml
@@ -13,7 +13,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/vendorId
-        - name: body
+        - name: OAuthAuthorizationToken
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/participants/v3_participants_userId_sendNotification.yml
+++ b/rest-api/src/main/resources/paths/participants/v3_participants_userId_sendNotification.yml
@@ -13,7 +13,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/userId
-        - name: body
+        - name: NotificationMessage
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/reports/v4_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/reports/v4_reports_identifier.yml
@@ -30,7 +30,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/identifier
-        - name: body
+        - name: ReportData
           description: Report data
           required: true
           in: body

--- a/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans.yml
+++ b/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans.yml
@@ -27,7 +27,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: SchedulePlan
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans_schedulePlanGuid.yml
+++ b/rest-api/src/main/resources/paths/scheduleplans/v3_scheduleplans_schedulePlanGuid.yml
@@ -28,7 +28,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/schedulePlanGuid
-        - name: body
+        - name: SchedulePlan
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies.yml
@@ -31,7 +31,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: Study
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_init.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_init.yml
@@ -8,7 +8,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: StudyAndUsers
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_self.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_self.yml
@@ -29,7 +29,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: Study
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_self_synapseProject.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_self_synapseProject.yml
@@ -9,7 +9,7 @@ post:
     security:
         - BridgeSecurity: []
     parameters:
-        - name: body
+        - name: String[]
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId.yml
@@ -25,7 +25,7 @@ post:
         -   BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
-        - name: body
+        - name: Study
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId_participants_userId_sendSmsMessage.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId_participants_userId_sendSmsMessage.yml
@@ -10,7 +10,7 @@ post:
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
         - $ref: ../../index.yml#/parameters/userId
-        - name: body
+        - name: SmsTemplate
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/studies/v3_studies_studyId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/studies/v3_studies_studyId_reports_identifier.yml
@@ -29,7 +29,7 @@ post:
     parameters:
         - $ref: ../../index.yml#/parameters/studyId
         - $ref: ../../index.yml#/parameters/identifier
-        - name: body
+        - name: ReportData
           description: Report data
           required: true
           in: body

--- a/rest-api/src/main/resources/paths/subpopulations/v3_subpopulations_subpopulationGuid_consents_signature.yml
+++ b/rest-api/src/main/resources/paths/subpopulations/v3_subpopulations_subpopulationGuid_consents_signature.yml
@@ -33,7 +33,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/subpopulationGuid
-        - name: body
+        - name: ConsentSignature
           description: A consent signature
           required: true
           in: body

--- a/rest-api/src/main/resources/paths/topics/v3_topics.yml
+++ b/rest-api/src/main/resources/paths/topics/v3_topics.yml
@@ -33,7 +33,7 @@ post:
     security:
         -   BridgeSecurity: []
     parameters:
-        - name: body
+        - name: NotificationTopic
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/topics/v3_topics_guid.yml
+++ b/rest-api/src/main/resources/paths/topics/v3_topics_guid.yml
@@ -27,7 +27,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: NotificationTopic
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/topics/v3_topics_guid_sendNotification.yml
+++ b/rest-api/src/main/resources/paths/topics/v3_topics_guid_sendNotification.yml
@@ -8,7 +8,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/guid
-        - name: body
+        - name: NotificationMessage
           required: true
           in: body
           schema:

--- a/rest-api/src/main/resources/paths/users/v4_users_self_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/users/v4_users_self_reports_identifier.yml
@@ -36,7 +36,7 @@ post:
         - BridgeSecurity: []
     parameters:
         - $ref: ../../index.yml#/parameters/identifier
-        - name: body
+        - name: ReportData
           required: true
           in: body
           schema:

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.17.1</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.18.0</version>
+        <version>0.18.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/AuthenticationHandlerTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/AuthenticationHandlerTest.java
@@ -66,7 +66,8 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void interceptRequiringAuthAddsHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(chain.request()).thenReturn(request);
@@ -88,7 +89,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void interceptRequiringAuthAddsHeaderToChangeStudy() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(chain.request()).thenReturn(request);
@@ -107,7 +109,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void interceptNoAuthDoesNotAddHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(chain.request()).thenReturn(request);
@@ -122,7 +125,8 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void authenticateRequiringAuthAddsHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(response.request()).thenReturn(request);
@@ -141,7 +145,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void after401YouDoNotNeedSessionTokenToSignOut() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(response.request()).thenReturn(request);
@@ -158,7 +163,8 @@ public class AuthenticationHandlerTest {
     
     @Test
     public void authenticateNoAuthDoesNotAddHeader() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         
         when(response.request()).thenReturn(request);
@@ -174,7 +180,8 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void authenticateDoesNotCallReauthIfSessionHasChanged() throws Exception {
-        UserSessionInfo session = new UserSessionInfo().sessionToken("sessionToken");
+        UserSessionInfo session = new UserSessionInfo();
+        Tests.setVariableValueInObject(session, "sessionToken", "sessionToken");
         when(userSessionInfoProvider.retrieveSession()).thenReturn(session);
         when(userSessionInfoProvider.getSession()).thenReturn(session);
 

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.sagebionetworks.bridge.rest.Tests.setVariableValueInObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -199,25 +200,28 @@ public class RestUtilsTest {
     
     private ConsentStatus requiredConsent(String guid, boolean isConsented, boolean isRecent) {
         ConsentStatus status = new ConsentStatus();
-        status.setSubpopulationGuid(guid);
-        status.setConsented(isConsented);
-        status.setRequired(true);
-        status.setSignedMostRecentConsent(isRecent);
+        setVariableValueInObject(status, "subpopulationGuid", guid);
+        setVariableValueInObject(status, "consented", isConsented);
+        setVariableValueInObject(status, "required", true);
+        setVariableValueInObject(status, "signedMostRecentConsent", isRecent);
         return status;
     }
     
     private ConsentStatus optConsent(String guid, boolean isConsented, boolean isRecent) {
         ConsentStatus status = new ConsentStatus();
-        status.setSubpopulationGuid(guid);
-        status.setConsented(isConsented);
-        status.setRequired(false);
-        status.setSignedMostRecentConsent(isRecent);
+        setVariableValueInObject(status, "subpopulationGuid", guid);
+        setVariableValueInObject(status, "consented", isConsented);
+        setVariableValueInObject(status, "required", false);
+        setVariableValueInObject(status, "signedMostRecentConsent", isRecent);
         return status;
     }
     
     private UserSessionInfo session(Map<String,ConsentStatus> statuses) {
         UserSessionInfo session = new UserSessionInfo();
-        session.setConsentStatuses(statuses);
+        try {
+            Tests.setVariableValueInObject(session, "consentStatuses", statuses);    
+        } catch(Exception e) {
+        }
         return session;
     }
     

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/Tests.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/Tests.java
@@ -1,7 +1,31 @@
 package org.sagebionetworks.bridge.rest;
 
+import java.lang.reflect.Field;
+
 public class Tests {
     public static String unescapeJson(String json) {
         return json.replaceAll("'", "\"");
     }
+    public static void setVariableValueInObject(Object object, String variable, Object value) {
+        try {
+            Field field = getFieldByNameIncludingSuperclasses(variable, object.getClass());
+            field.setAccessible(true);
+            field.set(object, value);
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @SuppressWarnings("rawtypes")
+    private static Field getFieldByNameIncludingSuperclasses(String fieldName, Class clazz) {
+        Field retValue = null;
+        try {
+            retValue = clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            Class superclass = clazz.getSuperclass();
+            if ( superclass != null ) {
+                retValue = getFieldByNameIncludingSuperclasses( fieldName, superclass );
+            }
+        }
+        return retValue;
+    }    
 }

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/UserSessionInfoProviderTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/UserSessionInfoProviderTest.java
@@ -62,10 +62,10 @@ public class UserSessionInfoProviderTest {
     UserSessionInfoProvider provider;
     
     @Before
-    public void before() {
-        userSessionInfo = new UserSessionInfo()
-                .email("email@email.com")
-                .sessionToken("sessionToken");
+    public void before() throws Exception {
+        userSessionInfo = new UserSessionInfo();
+        Tests.setVariableValueInObject(userSessionInfo, "email", "email@email.com");
+        Tests.setVariableValueInObject(userSessionInfo, "sessionToken", "sessionToken");
         
         signIn = new SignIn().email("email@email.com").password("password").study("test-study");
         
@@ -104,7 +104,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
 
         provider.reauthenticate();
@@ -132,7 +132,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         provider.reauthenticate();
@@ -151,7 +151,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         provider.reauthenticate();
@@ -170,7 +170,7 @@ public class UserSessionInfoProviderTest {
         doReturn(response).when(call).execute();
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         provider.reauthenticate();
@@ -180,7 +180,7 @@ public class UserSessionInfoProviderTest {
     }
 
     @Test
-    public void reauthenticationFailsWithNoCredentialsAllowingSignIn() throws IOException {
+    public void reauthenticationFailsWithNoCredentialsAllowingSignIn() throws Exception {
 
         signIn = new SignIn().email("email@email.com").study("test-study");
 
@@ -192,7 +192,7 @@ public class UserSessionInfoProviderTest {
         AuthenticationFailedException e1 = new AuthenticationFailedException("message", "endpoint");
         doThrow(e1).when(call).execute();
 
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
 
         try {
@@ -219,7 +219,7 @@ public class UserSessionInfoProviderTest {
 
         doReturn(userSessionInfo).when(response).body();
         
-        userSessionInfo.setReauthToken("reauthToken");
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", "reauthToken");
         provider.setSession(userSessionInfo);
         
         try {
@@ -246,20 +246,18 @@ public class UserSessionInfoProviderTest {
     }
 
     @Test
-    public void mergeReauthToken_A() {
+    public void mergeReauthToken_A() throws Exception {
         String reauthToken = "reauthToken";
         String sessionToken = "sessionToken";
-        UserSessionInfo userSessionInfo = new UserSessionInfo()
-                .sessionToken(sessionToken)
-                .reauthToken(reauthToken);
-
+        UserSessionInfo userSessionInfo = new UserSessionInfo();
+        Tests.setVariableValueInObject(userSessionInfo, "sessionToken", sessionToken);
+        Tests.setVariableValueInObject(userSessionInfo, "reauthToken", reauthToken);
 
         String newSessionToken = "newSessionToken";
-        UserSessionInfo newUserSessionInfo = new UserSessionInfo()
-                .sessionToken(newSessionToken);
+        UserSessionInfo newUserSessionInfo = new UserSessionInfo();
+        Tests.setVariableValueInObject(newUserSessionInfo, "sessionToken", newSessionToken);
 
-
-        UserSessionInfoProvider.mergeReauthToken(userSessionInfo, newUserSessionInfo);
+        newUserSessionInfo = UserSessionInfoProvider.mergeReauthToken(userSessionInfo, newUserSessionInfo);
 
         assertEquals(sessionToken, userSessionInfo.getSessionToken()); // check old session token
         assertEquals(newSessionToken, newUserSessionInfo.getSessionToken()); // check this isn't the old session
@@ -267,11 +265,11 @@ public class UserSessionInfoProviderTest {
 
         String newReauthToken = "newReauthToken";
         String evenNewerSessionToken = "evenNewerSessionToken";
-        UserSessionInfo evenNewerSession = new UserSessionInfo()
-                .sessionToken(evenNewerSessionToken)
-                .reauthToken(newReauthToken);
+        UserSessionInfo evenNewerSession = new UserSessionInfo();
+        Tests.setVariableValueInObject(evenNewerSession, "sessionToken", evenNewerSessionToken);
+        Tests.setVariableValueInObject(evenNewerSession, "reauthToken", newReauthToken);
 
-        UserSessionInfoProvider.mergeReauthToken(newUserSessionInfo, evenNewerSession);
+        evenNewerSession = UserSessionInfoProvider.mergeReauthToken(newUserSessionInfo, evenNewerSession);
 
         assertEquals(evenNewerSessionToken, evenNewerSession.getSessionToken());
         assertEquals(newReauthToken, evenNewerSession.getReauthToken()); // check we wrote a new reauth token


### PR DESCRIPTION
(This incorporates 0.18.0.) Swagger is ambiguous about the meaning of "required", but here we are going to start doing a better job differentiating between:

**required** - this value must be sent to the server. This is a weak indicator of overall validity, for example signIn needs to have one of email, phone, or externalId, so none of these are marked required. This value is not super useful but we try and indicate the required fields in order to indicate the *optional* fields.

**x-nullable: false** - the property will *always* be present and it will *always* have a value besides `null`. Since forever, iOS has had issues with JSON and null pointers, so x-nullable is a cue to that platform that it will not have to do null-pointer checks.

Almost all of our collections default to empty collections, so all of them are `x-nullable: false`. In addition, almost all booleans are `x-nullable: false` (if they are primitive values... Boolean is nullable and we're not 100% consistent in our usage as exposed through the API).