### PR TITLE
Small changes to external ID APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.19.1</version>
+    <version>0.19.2</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.1</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/study.yml
+++ b/rest-api/src/main/resources/definitions/study.yml
@@ -191,16 +191,6 @@ properties:
             **Can only be set by an administrator.** Should the system send a confirmation SMS message on sign 
             up if phone verification is enabled?
         x-nullable: false
-    externalIdValidationEnabled:
-        type: boolean
-        default: false
-        description: |
-            **Can only be set by an administrator.** Should external identifiers be validated? If this is false, then the external ID is treated as an unconstrained string. If this is true, the study designer will need to enter the list of valid codes into Bridge. Bridge will ensure that the following is true:
-
-            * When assigned, the ID will have to match one of the IDs entered into Bridge;
-            * A given ID will be assigned to one and only one user;
-            * Once assigned, it is not possible to change or remove the external ID from the user account.
-        x-nullable: false
     emailSignInEnabled:
         type: boolean
         default: false

--- a/rest-api/src/main/resources/paths/externalIds/v4_externalids_externalId.yml
+++ b/rest-api/src/main/resources/paths/externalIds/v4_externalids_externalId.yml
@@ -3,8 +3,7 @@ delete:
     summary: Delete an external ID
     tags: 
         - External Identifiers
-        - _For Developers
-        - _For Researchers
+        - _For Admins
     security:
         -   BridgeSecurity: []
     parameters:
@@ -15,4 +14,4 @@ delete:
         401:
             $ref: ../../responses/401.yml
         403:
-            $ref: ../../responses/403_not_developer_researcher.yml
+            $ref: ../../responses/403_not_admin.yml

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.1</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Delete external IDs is now only available to admins
- externalIdValidation flag removed (external IDs are always managed now)