### PR TITLE
Bump the version of the SDK?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: java
-jdk: openjdk7
+jdk: openjdk8
 script: 
   - mvn verify
 


### PR DESCRIPTION
We just recently saw this error and I believe it is due to an outdated SDK version.