### PR TITLE
Remove external ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.19.6</version>
+    <version>0.19.7</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.6</version>
+        <version>0.19.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -10,7 +10,8 @@ properties:
     externalId:
         type: string
         description: |
-            An externally-assignable identifier a research partner can use to re-identify a user's data in the exported data set (this must be provided by the application, it is not created by Bridge). The value can be set on creation or added on an account update, but it will be returned in the `externalIds` mapping which specifies the substudy within which the external ID was defined.
+            An externally-assignable identifier a research partner can use to re-identify a user's data in the exported data set (this must be provided by the application, it is not created by Bridge). The value can be set on creation or added on an account update, but it will be returned in the `externalIds` mapping which specifies the substudy within which the external ID was defined. This field will be null when 
+            retrieved from the server.
     id:
         type: string
         readOnly: true
@@ -82,6 +83,7 @@ properties:
         x-nullable: false
     externalIds:
         type: object
+        readOnly: true
         description: The exernal IDs this participant is associated to, mapped to the substudy that issued the external ID. Typically a user signs up with the external ID, and is assigned to that substudy as a result.
         additionalProperties:
             type: string

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -10,7 +10,7 @@ properties:
     externalId:
         type: string
         description: |
-            An externally-assignable identifier a research partner can use to re-identify a user's data in the exported data set (this must be provided by the application, it is not created by Bridge). It is a string that can be set or updated to any value without constraints, unless Bridge is configured to manage the study's external IDs. Then the ID must be submitted on sign up, and cannot be modified afterward.
+            An externally-assignable identifier a research partner can use to re-identify a user's data in the exported data set (this must be provided by the application, it is not created by Bridge). The value can be set on creation or added on an account update, but it will be returned in the `externalIds` mapping which specifies the substudy within which the external ID was defined.
     id:
         type: string
         readOnly: true

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -44,6 +44,13 @@ properties:
         items:
             type: string
         x-nullable: false
+    externalIds:
+        type: object
+        readOnly: true
+        description: A map of substudy ID to external ID for all the external IDs that have been assigned to this participant.
+        additionalProperties:
+            type: string
+        x-nullable: false
     type:
         type: string
         readOnly: true

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.6</version>
+        <version>0.19.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Some tweaks to the SDK (externalId field had been removed but externalIds had not been added as a read only field).