### PR TITLE
Mark survey options as exclusive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.19.22</version>
+    <version>0.19.23</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.22</version>
+        <version>0.19.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/survey_question_option.yml
+++ b/rest-api/src/main/resources/definitions/survey_question_option.yml
@@ -20,6 +20,10 @@ properties:
         $ref: ./image.yml
         description: |
             An optional Image element describing an image to show for this option. It should be shown along with the label (which will still be required).
+    exclusive:
+        type: boolean
+        description: |
+            If this option is selected, deselect all other options in the question. This is used for a "none of the above" type option in multiple choice questions.
     type:
         type: string
         readOnly: true

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.22</version>
+        <version>0.19.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
The survey engine will deselect all other options when an exclusive option is checked, and probably disable them as well. It is used for a "none of the above" option which is not the same as an "other" option.