### PR TITLE
Assessment configuration API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.19.27</version>
+    <version>0.19.28</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 
@@ -40,7 +40,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <surefire.version>2.18.1</surefire.version>
         <swagger-annotations.version>1.5.22</swagger-annotations.version>
-        <swagger-codegen-maven-plugin.version>2.4.4</swagger-codegen-maven-plugin.version>
+        <swagger-codegen-maven-plugin.version>2.4.12</swagger-codegen-maven-plugin.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <package-directory>org.sagebionetworks.bridge.rest</package-directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.27</version>
+        <version>0.19.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/assessment.yml
+++ b/rest-api/src/main/resources/definitions/assessment.yml
@@ -58,7 +58,7 @@ properties:
         additionalProperties:
             type: array
             items:
-                type: string
+                $ref: ../definitions/property_info.yml
     createdOn:
         type: string
         format: date-time

--- a/rest-api/src/main/resources/definitions/assessment_config.yml
+++ b/rest-api/src/main/resources/definitions/assessment_config.yml
@@ -1,0 +1,30 @@
+type: object
+required:
+    - config
+properties:
+    config:
+        type: object
+        description: The JSON configuration for this assessment.
+    createdOn:
+        type: string
+        format: date-time
+        readOnly: true
+        description: The date and time the app config was created.
+        x-nullable: false
+    modifiedOn:
+        type: string
+        format: date-time
+        readOnly: true
+        description: The date and time the app config was last modified.
+        x-nullable: false
+    version:
+        type: integer
+        format: int64
+        description: |
+            The optimistic locking version of the assessment config. This value must be submitted as part of the next update of the model. If it does not match the value on the server, a 409 error (Conflict) will prevent the update from occurring. It can also serve as a key to determine if a local cache of this `AssessmentConfig` revision needs to be updated.
+        x-nullable: false    
+    type:
+        type: string
+        readOnly: true
+        description: "AssessmentConfig"
+        x-nullable: false

--- a/rest-api/src/main/resources/definitions/index.yml
+++ b/rest-api/src/main/resources/definitions/index.yml
@@ -73,6 +73,8 @@ AppleAppLink:
     $ref: ./apple_app_link.yml
 Assessment:
     $ref: ./assessment.yml
+AssessmentConfig:
+    $ref: ./assessment_config.yml
 ClientInfo:
     $ref: ./client_info.yml
 CmsPublicKey:
@@ -163,6 +165,8 @@ Phone:
     $ref: ./phone.yml
 PhoneSignInRequest:
     $ref: ./phone_signin_request.yml
+PropertyInfo:
+    $ref: ./property_info.yml
 RecordExportStatusRequest:
     $ref: ./record_export_status_request.yml
 ReportData:

--- a/rest-api/src/main/resources/definitions/property_info.yml
+++ b/rest-api/src/main/resources/definitions/property_info.yml
@@ -20,5 +20,5 @@ properties:
     type:
         type: string
         readOnly: true
-        description: "NotificationMessage"
+        description: "PropertyInfo"
         x-nullable: false

--- a/rest-api/src/main/resources/definitions/property_info.yml
+++ b/rest-api/src/main/resources/definitions/property_info.yml
@@ -1,0 +1,24 @@
+type: object
+required:
+    - propName
+    - label
+properties:
+    propName:
+        type: string
+        description: The property name of the property on the JSON object that can be edited.
+        x-nullable: false
+    label:
+        type: string
+        description: A short label for the property.
+        x-nullable: false
+    description:
+        type: string
+        description: A longer description of the property and the allowable values that it can take.
+    propType:
+        type: string
+        description: A type hint to a UI editor for this property. The value is not constrained to support complex types, but we suggest 'string', 'number', or 'boolean' as basic values to support with editing tools.
+    type:
+        type: string
+        readOnly: true
+        description: "NotificationMessage"
+        x-nullable: false

--- a/rest-api/src/main/resources/paths/assessments/v1_assessments_guid_config.yml
+++ b/rest-api/src/main/resources/paths/assessments/v1_assessments_guid_config.yml
@@ -1,0 +1,38 @@
+get:
+    operationId: getAssessmentConfig
+    summary: Get the JSON config for this assessment
+    tags: 
+        - Assessments
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/guid
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/assessment_config.yml
+        401:
+            $ref: ../../responses/401.yml
+post:
+    operationId: updateAssessmentConfig
+    summary: Update the JSON config for this assessment
+    tags: 
+        - Assessments
+        - _For Developers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/guid
+        - name: AssessmentConfig
+          required: true
+          in: body
+          schema:
+            $ref: ../../definitions/assessment_config.yml
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/assessment_config.yml
+        401:
+            $ref: ../../responses/401.yml

--- a/rest-api/src/main/resources/paths/assessments/v1_assessments_guid_config_customize.yml
+++ b/rest-api/src/main/resources/paths/assessments/v1_assessments_guid_config_customize.yml
@@ -1,0 +1,23 @@
+post:
+    operationId: customizeAssessmentConfig
+    summary: Submit updates to the config that conform to the allowed customizations for the assessment. The object submitted to the server should be of the type `Map<String, Map<String, JsonNode>>`, where the first map associates a node identifier in the configuration to a map, and the second map associates one or more named properties of the node to a JsonNode update. This value can be of any type representable in JSON, since the server will persist it as part of the JSON configuration without type conversion (the update should still follow the schema of the configuration, or the client will not be able to interpret your configuration change).
+    tags: 
+        - Assessments
+        - _For Developers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/guid
+        - name: Customization update
+          required: true
+          in: body
+          schema:
+              type: object
+              additionalProperties: true
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/assessment_config.yml
+        401:
+            $ref: ../../responses/401.yml    

--- a/rest-api/src/main/resources/paths/index.yml
+++ b/rest-api/src/main/resources/paths/index.yml
@@ -73,6 +73,8 @@
     $ref: ./sharedassessments/v1_sharedassessments.yml
 /v1/sharedassessments/{guid}:
     $ref: ./sharedassessments/v1_sharedassessments_guid.yml
+/v1/sharedassessments/{guid}/config:
+    $ref: ./sharedassessments/v1_sharedassessments_guid_config.yml
 /v1/sharedassessments/{guid}/import:
     $ref: ./sharedassessments/v1_sharedassessments_guid_import.yml
 /v1/sharedassessments/{guid}/revisions:

--- a/rest-api/src/main/resources/paths/index.yml
+++ b/rest-api/src/main/resources/paths/index.yml
@@ -47,6 +47,10 @@
     $ref: ./assessments/v1_assessments.yml
 /v1/assessments/{guid}:
     $ref: ./assessments/v1_assessments_guid.yml
+/v1/assessments/{guid}/config:
+    $ref: ./assessments/v1_assessments_guid_config.yml
+/v1/assessments/{guid}/config/customize:
+    $ref: ./assessments/v1_assessments_guid_config_customize.yml
 /v1/assessments/{guid}/publish:
     $ref: ./assessments/v1_assessments_guid_publish.yml
 /v1/assessments/{guid}/revisions:

--- a/rest-api/src/main/resources/paths/sharedassessments/v1_sharedassessments_guid_config.yml
+++ b/rest-api/src/main/resources/paths/sharedassessments/v1_sharedassessments_guid_config.yml
@@ -1,0 +1,15 @@
+get:
+    operationId: getSharedAssessmentConfig
+    summary: Get the configuration JSON for a shared assessmentapp context.
+    tags: 
+        - Shared Assessments
+        - Public
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/guid
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/assessment_config.yml

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.19.27</version>
+        <version>0.19.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/RestUtils.java
@@ -64,6 +64,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import okhttp3.MediaType;
@@ -145,6 +146,15 @@ public class RestUtils {
      */
     public static <T> T toType(Object object, Class<T> type) {
         return GSON.fromJson(GSON.toJson(object), type);
+    }
+    
+    /**
+     * Convert an object returned as part of the API to a JSON object model  
+     * @param object
+     * @return a JSON object model of the object.
+     */
+    public static JsonElement toJSON(Object object) {
+        return GSON.toJsonTree(object);
     }
     
     /**

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/RestUtilsTest.java
@@ -18,6 +18,8 @@ import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 public class RestUtilsTest {
     
@@ -190,6 +192,29 @@ public class RestUtilsTest {
     @Test
     public void acceptLanguageNullsEmptyRemoved() {
         assertEquals("de,en", RestUtils.getAcceptLanguage(Lists.<String>newArrayList("","de",null,"en")));
+    }
+    
+    @Test
+    public void toJSON() {
+        ClientInfo info = new ClientInfo()
+                .appName("appName")
+                .appVersion(10)
+                .deviceName("deviceName")
+                .osName("osName")
+                .osVersion("1.2.3")
+                .sdkName("sdkName")
+                .sdkVersion(5);
+        
+        JsonElement element = RestUtils.toJSON(info);
+        JsonObject el = element.getAsJsonObject();
+
+        assertEquals("appName", el.get("appName").getAsString());
+        assertEquals(10, el.get("appVersion").getAsInt());
+        assertEquals("deviceName", el.get("deviceName").getAsString());
+        assertEquals("osName", el.get("osName").getAsString());
+        assertEquals("1.2.3", el.get("osVersion").getAsString());
+        assertEquals("sdkName", el.get("sdkName").getAsString());
+        assertEquals(5, el.get("sdkVersion").getAsInt());
     }
     
     private Map<String,ConsentStatus> map(ConsentStatus status1, ConsentStatus status2) {


### PR DESCRIPTION
Unfortunately, Swagger cannot generate anything but an Object signature for Map<String, Map<String, JsonElement>>, so a RestUtils method was added to convert an object into a GSON JsonElement object graph (which then serializes correctly when passed as an object to the customize method).