### PR TITLE
Fix permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.22.17</version>
+    <version>0.22.18</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.22.17</version>
+        <version>0.22.18</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/paths/organizations/v1_organizations.yml
+++ b/rest-api/src/main/resources/paths/organizations/v1_organizations.yml
@@ -2,7 +2,7 @@ get:
     operationId: getOrganizations
     summary: Get all of the organizations in an app
     description: |
-        Return all the organizations that have been defined for the app context of the caller. These organization objects only contain the name and identifier of the organization (for the full record, call `getOrganization()`).
+        Return all the organizations that have been defined for the app context of the caller. For most roles this will only return the caller’s organization, but admins can view all organizations. These organization objects only contain the name and identifier of the organization (for the full record, call `getOrganization()`).
     tags:
         - Organizations
     security:

--- a/rest-api/src/main/resources/paths/organizations/v1_organizations.yml
+++ b/rest-api/src/main/resources/paths/organizations/v1_organizations.yml
@@ -4,10 +4,6 @@ get:
     description: |
         Return all the organizations that have been defined for the app context of the caller. These organization objects only contain the name and identifier of the organization (for the full record, call `getOrganization()`).
     tags:
-        - _For Admins
-        - _For Researchers
-        - _For Developers
-        - _For Org Admins
         - Organizations
     security:
         - BridgeSecurity: []
@@ -22,15 +18,13 @@ get:
         401:
             $ref: ../../responses/401.yml
         403:
-            $ref: ../../responses/403_not_superadmin.yml
-        410:
-            $ref: ../../responses/410.yml
+            $ref: ../../responses/403_not_administrative.yml
 post:
     operationId: createOrganization
     summary: Create a new organization
     description: Create a new organization.
     tags:
-        - _For Superadmins
+        - _For Admins
         - Organizations
     security:
         -   BridgeSecurity: []
@@ -48,6 +42,4 @@ post:
         401:
             $ref: ../../responses/401.yml
         403:
-            $ref: ../../responses/403_not_superadmin.yml
-        410:
-            $ref: ../../responses/410.yml
+            $ref: ../../responses/403_not_admin.yml

--- a/rest-api/src/main/resources/paths/organizations/v1_organizations_nonmembers.yml
+++ b/rest-api/src/main/resources/paths/organizations/v1_organizations_nonmembers.yml
@@ -3,10 +3,6 @@ post:
     summary: Get paged listing of unassigned administrative accounts
     description: Get administrative accounts that have not been assigned to an organization. These are the accounts that still need to be assigned to an organization.
     tags:
-        - _For Admins
-        - _For Developers
-        - _For Researchers
-        - _For Org Admins
         - Organizations
     security:
         - BridgeSecurity: []
@@ -24,3 +20,5 @@ post:
                 $ref: ../../definitions/paged_resources/account_summary.yml
         401:
             $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_administrative.yml

--- a/rest-api/src/main/resources/paths/organizations/v1_organizations_orgId.yml
+++ b/rest-api/src/main/resources/paths/organizations/v1_organizations_orgId.yml
@@ -1,10 +1,8 @@
 get:
     operationId: getOrganization
     summary: Get an organization
-    description: Get a single organization record.
+    description: Get a single organization record. Caller must be a member of the organization to retrieve the record (or an admin).
     tags:
-        - _For Superadmins
-        - _For Org Admins
         - Organizations
     security:
         - BridgeSecurity: []
@@ -18,17 +16,15 @@ get:
         401:
             $ref: ../../responses/401.yml
         403:
-            $ref: ../../responses/403_not_superadmin.yml
-        410:
-            $ref: ../../responses/410.yml
+            $ref: ../../responses/403_not_administrative.yml
 post:
     operationId: updateOrganization
     summary: Update an organization
     description: |
         Update an existing organization.
     tags:
-        - _For Superadmins
         - _For Org Admins
+        - _For Admins
         - Organizations
     security:
         -   BridgeSecurity: []
@@ -47,9 +43,7 @@ post:
         401:
             $ref: ../../responses/401.yml
         403:
-            $ref: ../../responses/403_not_superadmin.yml
-        410:
-            $ref: ../../responses/410.yml
+            $ref: ../../responses/403_not_org_admin_admin.yml
 delete:
     operationId: deleteOrganization
     summary: Delete an organization.

--- a/rest-api/src/main/resources/paths/organizations/v1_organizations_orgId_members.yml
+++ b/rest-api/src/main/resources/paths/organizations/v1_organizations_orgId_members.yml
@@ -2,10 +2,6 @@ post:
     operationId: getMembers
     summary: Get members of organization (using search terms). Caller must be a member of the organization.
     tags:
-        - _For Admins
-        - _For Developers
-        - _For Researchers
-        - _For Org Admins
         - Organizations
     security:
         - BridgeSecurity: []

--- a/rest-api/src/main/resources/paths/organizations/v1_organizations_orgId_studies.yml
+++ b/rest-api/src/main/resources/paths/organizations/v1_organizations_orgId_studies.yml
@@ -2,10 +2,6 @@ get:
     operationId: getSponsoredStudies
     summary: Get the studies that are sponsored by this organization.
     tags:
-        - _For Admins
-        - _For Developers
-        - _For Researchers
-        - _For Org Admins
         - Organizations
     security:
         - BridgeSecurity: []
@@ -21,4 +17,4 @@ get:
         401:
             $ref: ../../responses/401.yml
         403:
-            $ref: ../../responses/403_not_developer_researcher_admin.yml
+            $ref: ../../responses/403_not_administrative.yml

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.22.17</version>
+        <version>0.22.18</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
The swagger documentation was wrong even for the permissions prior to these changes; updated to reflect the current more lenient permissions. Removing the - _For <role> APIs because these are difficult to maintain for APIs that accept all administrative users (tbh I'm kind of sorry we got started with them at all).