### PR TITLE
Adding clientTimeZone field to participant accounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.22.21</version>
+    <version>0.22.22</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.22.21</version>
+        <version>0.22.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -96,5 +96,6 @@ properties:
         description: Optional note related to user account. Can only be edited and viewed by an administrative account.
     clientTimeZone:
         type: string
+        example: 'America/Los_Angeles'
         description: |
-            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name (eg. "America/Los_Angeles").
+            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name.

--- a/rest-api/src/main/resources/definitions/abstract_study_participant.yml
+++ b/rest-api/src/main/resources/definitions/abstract_study_participant.yml
@@ -94,3 +94,7 @@ properties:
     note:
         type: string
         description: Optional note related to user account. Can only be edited and viewed by an administrative account.
+    clientTimeZone:
+        type: string
+        description: |
+            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name (eg. "America/Los_Angeles").

--- a/rest-api/src/main/resources/definitions/account.yml
+++ b/rest-api/src/main/resources/definitions/account.yml
@@ -94,5 +94,6 @@ properties:
         description: Optional note related to user account. Can only be edited and viewed by an administrative account.
     clientTimeZone:
         type: string
+        example: 'America/Los_Angeles'
         description: |
-            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name (eg. "America/Los_Angeles").
+            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name.

--- a/rest-api/src/main/resources/definitions/account.yml
+++ b/rest-api/src/main/resources/definitions/account.yml
@@ -92,3 +92,7 @@ properties:
     note:
         type: string
         description: Optional note related to user account. Can only be edited and viewed by an administrative account.
+    clientTimeZone:
+        type: string
+        description: |
+            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name (eg. "America/Los_Angeles").

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -78,5 +78,6 @@ properties:
     clientTimeZone:
         type: string
         readOnly: true
+        example: 'America/Los_Angeles'
         description: |
-            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name (eg. "America/Los_Angeles").
+            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name.

--- a/rest-api/src/main/resources/definitions/account_summary.yml
+++ b/rest-api/src/main/resources/definitions/account_summary.yml
@@ -75,3 +75,8 @@ properties:
         type: string
         readOnly: true
         description: Optional note related to user account.
+    clientTimeZone:
+        type: string
+        readOnly: true
+        description: |
+            Participant's time zone. Can be updated or deleted. Must be an IANA time zone name (eg. "America/Los_Angeles").

--- a/rest-api/src/main/resources/definitions/study_participant.yml
+++ b/rest-api/src/main/resources/definitions/study_participant.yml
@@ -30,7 +30,7 @@ allOf:
             x-nullable: false
         timeZone:
             type: string
-            description: User's original time zone, as measured by the timezone used to request activities, as a string offset in ISO8601 format.
+            description: User's original time zone, as measured by the timezone used to request activities, as a string offset in ISO8601 format. Related to the v3 scheduling API, it is not always set or reliable.
         type:
             type: string
             readOnly: true

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.22.21</version>
+        <version>0.22.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
For [BRIDGE-3047](https://sagebionetworks.jira.com/browse/BRIDGE-3047).

Adding clientTimeZone field to StudyParticipant as a reference for the participant's local time zone.