### PR TITLE
Split participant report APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.23.1</version>
+    <version>0.23.3</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.23.1</version>
+        <version>0.23.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/paths/index.yml
+++ b/rest-api/src/main/resources/paths/index.yml
@@ -599,6 +599,16 @@
     $ref: ./studies/v5_studies_studyId_participants_self_adherence.yml
 /v5/studies/{studyId}/participants/self/timeline:
     $ref: ./studies/v5_studies_studyId_participants_self_timeline.yml
+/v5/studies/{studyId}/participants/reports:
+    $ref: ./studies/v5_studies_studyId_participants_reports.yml
+/v5/studies/{studyId}/participants/reports/{identifier}:
+    $ref: ./studies/v5_studies_studyId_participants_reports_identifier.yml
+/v5/studies/{studyId}/participants/{userId}/reports/{identifier}:
+    $ref: ./studies/v5_studies_studyId_participants_userId_reports_identifier.yml
+/v5/studies/{studyId}/participants/{userId}/reports/{identifier}/{date}:
+    $ref: ./studies/v5_studies_studyId_participants_userId_reports_identifier_date.yml
+/v5/studies/{studyId}/participants/self/reports/{identifier}:
+    $ref: ./studies/v5_studies_studyId_participants_self_reports_identifier.yml
 /v5/studies/{studyId}/design:
     $ref: ./studies/v5_studies_studyId_design.yml
 /v5/studies/{studyId}/recruit:

--- a/rest-api/src/main/resources/paths/participants/v4_participants_userId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/participants/v4_participants_userId_reports_identifier.yml
@@ -31,7 +31,6 @@ post:
         - Participant Reports
         - _For Developers
         - _For Workers
-        - _For Study Coordinators
     security:
         - BridgeSecurity: []
     parameters:
@@ -42,7 +41,6 @@ post:
           in: body
           schema:
             $ref: ../../definitions/report_data.yml
-
     responses:
         201:
             $ref: ../../responses/201_message.yml

--- a/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_reports.yml
+++ b/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_reports.yml
@@ -1,0 +1,20 @@
+get:
+    operationId: getStudyParticipantReportIndices
+    summary: Get the indices (identifiers) of all the reports available for participants in the given study.
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/paged_resources/report_index.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml

--- a/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_reports_identifier.yml
@@ -1,0 +1,42 @@
+get:
+    operationId: getStudyParticipantReportIndex
+    summary: Get a single report index with some additional metadata about the report series.
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/identifier
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/report_index.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml
+delete:
+    operationId: deleteStudyParticipantReportIndex
+    summary: Delete a single report index (note that deleting an index in effect makes all report records under that identifier less accessible...the reports are not deleted, but they are not listed in the indices, either).
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/identifier
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml

--- a/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_self_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_self_reports_identifier.yml
@@ -1,0 +1,49 @@
+get:
+    operationId: getUsersStudyParticipantReport
+    summary: Get a series of report records for a specific date and time range for the caller (this API uses dates and times and not just dates; use a standard time of day portion like “T00:00:00.000Z” if a time portion is unnecessary, being sure to create and retrieve records with the same set time).
+    tags:
+        - Study Participants
+        - _For Consented Users
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/identifier
+        - $ref: ../../index.yml#/parameters/startTime
+        - $ref: ../../index.yml#/parameters/endTime
+        - $ref: ../../index.yml#/parameters/offsetKey
+        - $ref: ../../index.yml#/parameters/pageSize
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/paged_resources/forward_cursor_report_data.yml
+        401:
+            $ref: ../../responses/401.yml
+        412:
+            $ref: ../../responses/412.yml
+post:
+    operationId: saveUsersStudyParticipantReportRecord
+    summary: Add a participant report for a single date and time for the caller (this API uses dates and times and not just dates; use a standard time of day portion like “T00:00:00.000Z” if a time portion is unnecessary, being sure to create and retrieve records with the same set time).
+    tags:
+        - Study Participants
+        - _For Consented Users
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/identifier
+        - name: ReportData
+          required: true
+          in: body
+          schema:
+            $ref: ../../definitions/report_data.yml
+    responses:
+        201:
+            description: CREATED
+            schema:
+                $ref: ../../definitions/message.yml
+        401:
+            $ref: ../../responses/401.yml
+        412:
+            $ref: ../../responses/412.yml

--- a/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_userId_reports_identifier.yml
+++ b/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_userId_reports_identifier.yml
@@ -1,0 +1,75 @@
+get:
+    operationId: getStudyParticipantReport
+    summary: Get a series of report records for a specific date and time range (this API uses dates and times and not just dates; use a standard time of day portion like “T00:00:00.000Z” if a time portion is unnecessary, being sure to create and retrieve records with the same set time).
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+        - $ref: ../../index.yml#/parameters/startTime
+        - $ref: ../../index.yml#/parameters/endTime
+        - $ref: ../../index.yml#/parameters/offsetKey
+        - $ref: ../../index.yml#/parameters/pageSize
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/paged_resources/forward_cursor_report_data.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml
+post:
+    operationId: saveStudyParticipantReportRecord
+    summary: Add a participant report for a single date and time (this API uses dates and times and not just dates; use a standard time of day portion like “T00:00:00.000Z” if a time portion is unnecessary, being sure to create and retrieve records with the same set time).
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+        - name: ReportData
+          required: true
+          in: body
+          schema:
+            $ref: ../../definitions/report_data.yml
+    responses:
+        201:
+            description: CREATED
+            schema:
+                $ref: ../../definitions/message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml
+delete:
+    operationId: deleteStudyParticipantReport
+    summary: Delete all records for a report for one member of the study.
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml

--- a/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_userId_reports_identifier_date.yml
+++ b/rest-api/src/main/resources/paths/studies/v5_studies_studyId_participants_userId_reports_identifier_date.yml
@@ -1,0 +1,28 @@
+delete:
+    operationId: deleteStudyParticipantReportRecord
+    summary: Delete one record for a report for one member of the study.
+    tags:
+        - Study Participants
+        - _For Study Coordinators
+        - _For Study Designers
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/userId
+        - $ref: ../../index.yml#/parameters/identifier
+        - name: date
+          in: path
+          description: The date and time of the record to delete
+          type: string
+          format: date-time
+          required: true
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_study_designer_coordinator.yml

--- a/rest-api/src/main/resources/responses/403_not_study_designer_coordinator.yml
+++ b/rest-api/src/main/resources/responses/403_not_study_designer_coordinator.yml
@@ -1,0 +1,4 @@
+description: |
+    User cannot access this service because they do not have an administrative role (no study coordinator or study designer role on account).
+schema:
+    $ref: ../definitions/message.yml

--- a/rest-api/src/main/resources/responses/index.yml
+++ b/rest-api/src/main/resources/responses/index.yml
@@ -50,6 +50,8 @@
     $ref: ./403_not_study_coordinator_researcher.yml
 403_not_study_coordinator_admin:
     $ref: ./403_not_study_coordinator_admin.yml
+403_not_study_designer_coordinator.yml:
+    $ref: ./403_not_study_designer_coordinator.yml
 403_not_study_designer_developer.yml:
     $ref: ./403_not_study_designer_developer.yml
 403_not_superadmin:

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.23.1</version>
+        <version>0.23.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Create a separate set of APIs for participant reports vis-a-vis study-scoped administrators. Participant data and files do not have Administrative APIs, but if they did, we could/should split them too.