### PR TITLE
We need to enumerate the test properties for environments where there is no property file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.23.12</version>
+    <version>0.23.13</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.23.12</version>
+        <version>0.23.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.23.12</version>
+        <version>0.23.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
@@ -47,7 +47,16 @@ public final class Config {
         DEVICE_NAME,
         OS_NAME,
         OS_VERSION,
-        SDK_VERSION;
+        SDK_VERSION,
+        
+        // test properties... not documented for public use
+        DEV_NAME,
+        ADMIN_EMAIL,
+        ADMIN_PASSWORD,
+        SYNAPSE_TEST_USER,
+        SYNAPSE_TEST_USER_ID,
+        SYNAPSE_TEST_USER_PASSWORD,
+        SYNAPSE_TEST_USER_API_KEY;
 
         public String getPropertyName() {
             return this.name().replace("_", ".").toLowerCase();


### PR DESCRIPTION
In environments like Jenkins where all the properties are passed as system properties, this Config implementation fails because the properties aren't all found and enumerated. Adding back the test properties so they are enumerated correctly (for now...our config implementation has a fatal flaw in this regard that we need to think about).