### PR TITLE
Add environment-specific property support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.23.14</version>
+    <version>0.23.15</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.23.14</version>
+        <version>0.23.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.23.14</version>
+        <version>0.23.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
@@ -7,9 +7,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.Set;
 
 import org.sagebionetworks.bridge.rest.model.Environment;
 import org.sagebionetworks.bridge.rest.model.SignIn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * <p>The Config class provides the implementation for loading configuration for the ClientManager. The 
@@ -25,10 +30,18 @@ import org.sagebionetworks.bridge.rest.model.SignIn;
  * </pre>
  */
 public final class Config {
+    private static final Logger LOG = LoggerFactory.getLogger(Config.class);
 
     private static final String CONFIG_FILE = "/bridge-sdk.properties";
     private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/bridge-sdk.properties";
-
+    /**
+     * We chose two property names that are identical to System properties that are set in a Java environment. 
+     * For backwards compatibility reasons, we do not want to pick up these values from the environment (e.g.
+     * if this is being used in a Java environment, the setting of these properties in bridge-sdk.properties
+     * would just be ignored).
+     */
+    private static final Set<String> OVERLOADED_SYSTEM_PROPERTIES = ImmutableSet.of("os.name", "os.version");
+    
     public enum Props {
         // Base properties
         ENV, 
@@ -62,9 +75,37 @@ public final class Config {
             return this.name().replace("_", ".").toLowerCase();
         }
     }
+    
+    private static interface ConfigReader {
+        String read(String name);
+    }
+    
+    private final ConfigReader envReader = new ConfigReader() {
+        @Override
+        public String read(String name) {
+            try {
+                // Change to a valid environment variable name
+                name = name.toUpperCase().replace('.', '_');
+                return System.getenv(name);
+            } catch (SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
+
+    private final ConfigReader sysReader = new ConfigReader() {
+        @Override
+        public String read(String name) {
+            try {
+                return System.getProperty(name);
+            } catch (SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
 
     private Properties config;
-    private Environment environment;
+    private Environment environment = Environment.LOCAL;
 
     public Config() {
         this(CONFIG_FILE, USER_CONFIG_FILE);
@@ -82,21 +123,26 @@ public final class Config {
         }
 
         // Finally, overwrite from environment variables and system properties
-        for (Props key : Props.values()) {
-            String value = System.getenv(key.name());
-            if (value == null) {
-                value = System.getProperty(key.name());
-            }
-            if (value != null) {
-                config.setProperty(key.getPropertyName(), value);
-            }
+        String envName = sysReader.read("env");
+        if (envName == null) {
+            envName = envReader.read("env");
         }
-        String envName = config.getProperty("env");
+        if (envName == null) {
+            envName = config.getProperty("env");    
+        }
         if (envName != null) {
             environment = Environment.valueOf(envName.toUpperCase());
         }
+        if (LOG.isInfoEnabled()) {
+            LOG.info("SDK Config environment: " + environment);    
+        }
+        this.config = new Properties(collapse(config, environment.name().toLowerCase()));
+        
+        for (String prop : config.stringPropertyNames()) {
+            System.out.println(prop + " = " + config.getProperty(prop));
+        }
     }
-
+    
     private void loadProperties(final String fileName, final Properties properties) {
         File file = new File(fileName);
         if (file.exists()) {
@@ -106,6 +152,60 @@ public final class Config {
                 throw new RuntimeException(e);
             }
         }
+    }
+    
+    /**
+     * Collapses the properties into new properties relevant to the current
+     * environment. 1) Default properties usually bundled in the code base as
+     * resources. 2) Overwrite with properties read from the user's home
+     * directory 3) Merge the properties to the current environment 4) Overwrite
+     * with properties read from the environment variables. 5) Overwrite with
+     * properties read from the command-line arguments.
+     */
+    private Properties collapse(final Properties properties, final String envName) {
+        Properties collapsed = new Properties();
+        // Read the default properties
+        for (final String key : properties.stringPropertyNames()) {
+            if (isDefaultProperty(key)) {
+                collapsed.setProperty(key, properties.getProperty(key));
+            }
+        }
+        // Overwrite with properties for the current environment
+        for (final String key : properties.stringPropertyNames()) {
+            if (key.startsWith(envName + ".")) {
+                String strippedName = key.substring(envName.length() + 1);
+                collapsed.setProperty(strippedName, properties.getProperty(key));
+            }
+        }
+        // Overwrite with environment variables and system properties
+        for (final String key : properties.stringPropertyNames()) {
+            String value = envReader.read(key);
+            if (value == null && !OVERLOADED_SYSTEM_PROPERTIES.contains(key)) {
+                value = sysReader.read(key);
+            }
+            if (value != null) {
+                if (key.startsWith(envName + ".")) {
+                    String strippedName = key.substring(envName.length() + 1);
+                    collapsed.setProperty(strippedName, value);
+                } else {
+                    collapsed.setProperty(key, value);
+                }
+            }
+        }
+        return collapsed;
+    }
+    
+    /**
+     * When the property is not bound to a particular environment.
+     */
+    private boolean isDefaultProperty(final String propName) {
+        for (Environment env : Environment.values()) {
+            String envPrefix = env.name().toLowerCase() + ".";
+            if (propName.startsWith(envPrefix)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
+++ b/rest-client/src/main/java/org/sagebionetworks/bridge/rest/Config.java
@@ -122,10 +122,11 @@ public final class Config {
             }
         }
 
-        // Finally, overwrite from environment variables and system properties
-        String envName = sysReader.read("env");
+        // Finally, overwrite from environment variables and system properties. property values 
+        // are overridden by environment variables, which are overridden by system properties.
+        String envName = envReader.read("env");
         if (envName == null) {
-            envName = envReader.read("env");
+            envName = sysReader.read("env");
         }
         if (envName == null) {
             envName = config.getProperty("env");    
@@ -137,10 +138,6 @@ public final class Config {
             LOG.info("SDK Config environment: " + environment);    
         }
         this.config = new Properties(collapse(config, environment.name().toLowerCase()));
-        
-        for (String prop : config.stringPropertyNames()) {
-            System.out.println(prop + " = " + config.getProperty(prop));
-        }
     }
     
     private void loadProperties(final String fileName, final Properties properties) {
@@ -161,6 +158,8 @@ public final class Config {
      * directory 3) Merge the properties to the current environment 4) Overwrite
      * with properties read from the environment variables. 5) Overwrite with
      * properties read from the command-line arguments.
+     * 
+     * 
      */
     private Properties collapse(final Properties properties, final String envName) {
         Properties collapsed = new Properties();
@@ -177,6 +176,10 @@ public final class Config {
                 collapsed.setProperty(strippedName, properties.getProperty(key));
             }
         }
+        
+        // Finally, overwrite from environment variables and system properties. property values 
+        // are overridden by environment variables, which are overridden by system properties.
+
         // Overwrite with environment variables and system properties
         for (final String key : properties.stringPropertyNames()) {
             String value = envReader.read(key);

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ClientManagerTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ClientManagerTest.java
@@ -28,7 +28,6 @@ public class ClientManagerTest {
     public void testInitFromConfig() {
         SignIn accountSignIn = new SignIn().appId("app-identifier").email("account@email.com")
                 .password("account-password");
-        SignIn adminSignIn = new SignIn().appId("app-identifier").email("admin@email.com").password("admin-password");
         
         doReturn(accountSignIn).when(config).getAccountSignIn();
         doReturn("app-identifier").when(config).getAccountAppId();

--- a/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ConfigTest.java
+++ b/rest-client/src/test/java/org/sagebionetworks/bridge/rest/ConfigTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.rest;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
@@ -9,10 +8,36 @@ public class ConfigTest {
 
     @Test
     public void test() {
-        Config config = new Config();
+        // The default constructor assumes that home directory properties are set a specific way, which we
+        // don't want for this test. So we force examination only of the test properties file.
+        Config config = new Config("/bridge-sdk.properties");
         assertEquals("5", config.getSdkVersion());
         assertEquals("testName", config.getAppName());
         assertEquals("testName", config.fromProperty(Config.Props.APP_NAME));
         assertEquals("warn", config.getLogLevel());
+        assertEquals("33", config.getAppVersion());
+        assertEquals("Swankie Device", config.getDeviceName());
+        assertEquals("en,fr", config.getLanguages());
+        assertEquals("webOS", config.getOsName());
+        assertEquals("ultimate", config.getOsVersion());
+    }
+    
+    @Test
+    public void testEnvironmentSubstitutionWithProperty() {
+        Config config = new Config("/bridge-sdk-staging.properties");
+        assertEquals("staging testName", config.getAppName());
+        assertEquals("33", config.getAppVersion());
+    }
+
+    @Test
+    public void testEnvironmentSubstitutionWithSystemProp() {
+        try {
+            System.setProperty("env", "production");
+            Config config = new Config("/bridge-sdk.properties");
+            assertEquals("production testName", config.getAppName());
+            assertEquals("33", config.getAppVersion());
+        } finally {
+            System.setProperty("env", "local");
+        }
     }
 }

--- a/rest-client/src/test/resources/bridge-sdk-staging.properties
+++ b/rest-client/src/test/resources/bridge-sdk-staging.properties
@@ -1,0 +1,4 @@
+env = staging
+app.version = 33
+app.name = testName
+staging.app.name = staging testName

--- a/rest-client/src/test/resources/bridge-sdk.properties
+++ b/rest-client/src/test/resources/bridge-sdk.properties
@@ -6,3 +6,5 @@ device.name = Swankie Device
 os.name = webOS
 os.version = ultimate
 languages = en,fr
+
+production.app.name = production testName


### PR DESCRIPTION
This is very similar to the Config implementation used by our server code, but I didn't want to use that implementation because 1) it would require our SDK to pull in our server-oriented bridge-base package and 2) that implementation has some "quirks."