### PR TITLE
Api to revert study to design phase (BRIDGE-3339)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.sagebionetworks.bridge</groupId>
     <artifactId>sdk-group</artifactId>
     <!-- Please use the maven versions plugin to manage this, e.g.`mvn versions:set -DnewVersion=0.8.1`-->
-    <version>0.25.9</version>
+    <version>0.25.10</version>
     <packaging>pom</packaging>
     <url>https://api.sagebridge.org</url>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.25.9</version>
+        <version>0.25.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rest-api/src/main/resources/index.yml
+++ b/rest-api/src/main/resources/index.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-    version: "0.25.9"
+    version: "0.25.10"
     title: Bridge Server API
 host: webservices.sagebridge.org
 basePath: /

--- a/rest-api/src/main/resources/paths/index.yml
+++ b/rest-api/src/main/resources/paths/index.yml
@@ -585,6 +585,8 @@
     $ref: ./studies/v5_studies_studyId_schedule.yml
 /v5/studies/{studyId}/timeline:
     $ref: ./studies/v5_studies_studyId_timeline.yml
+/v5/studies/{studyId}/reverttodesign:
+    $ref: ./studies/v5_studies_studyId_reverttodesign.yml
 /v5/studies/{studyId}/adherence/weekly:
     $ref: ./studies/v5_studies_studyId_adherence_weekly.yml
 /v5/studies/{studyId}/adherence/stats:

--- a/rest-api/src/main/resources/paths/studies/v5_studies_studyId_reverttodesign.yml
+++ b/rest-api/src/main/resources/paths/studies/v5_studies_studyId_reverttodesign.yml
@@ -1,0 +1,18 @@
+post:
+    operationId: revertStudyToDesign
+    summary: Transition a study’s phase to “design” disregarding the current phase of the study.
+    tags:
+        - _For Superadmins
+    security:
+        - BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+    responses:
+        200:
+            description: OK
+            schema:
+                $ref: ../../definitions/study.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_superadmin.yml     

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sdk-group</artifactId>
         <groupId>org.sagebionetworks.bridge</groupId>
-        <version>0.25.9</version>
+        <version>0.25.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Adding API allowing superadmins to move a study back to design outside of the typical study lifecycle.